### PR TITLE
Webpack 5 splitChunks breaks WebpackDevServer fix

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -76,7 +76,7 @@ module.exports = function override(config, env) {
     ignoreWarnings: [/Failed to parse source map/],
     optimization: {
       ...config.optimization,
-      splitChunks: {
+      splitChunks: env === "production" ? {
         chunks: "all",
         minSize: 1024 * 20,
         maxSize: 1024 * 1024 * 20,
@@ -97,7 +97,7 @@ module.exports = function override(config, env) {
             reuseExistingChunk: true,
           },
         },
-      },
+      } : config.optimization.splitChunks,
     },
   };
 };


### PR DESCRIPTION
This PR fixes an issue with running `npm start` after the chunking change where it just hangs.