### PR TITLE
#73 - add logic to fetch metaplet uri metadata whenever it is necessary

### DIFF
--- a/src/components/TokenSelectors/SolanaTokenPicker.tsx
+++ b/src/components/TokenSelectors/SolanaTokenPicker.tsx
@@ -76,6 +76,7 @@ export default function SolanaSourceTokenSelector(
       return (
         (account.isNativeAsset && account.logo) ||
         memoizedTokenMap.get(account.mintKey)?.logoURI ||
+        metaplex.data?.get(account.mintKey)?.data?.uriMetadata?.image ||
         metaplex.data?.get(account.mintKey)?.data?.uri ||
         undefined
       );

--- a/src/utils/metaplex.ts
+++ b/src/utils/metaplex.ts
@@ -229,6 +229,7 @@ export class Data {
   name: string;
   symbol: string;
   uri: string;
+  uriMetadata: URIMetadata;
   sellerFeeBasisPoints: number;
   creators: Creator[] | null;
   constructor(args: {
@@ -241,8 +242,16 @@ export class Data {
     this.name = args.name;
     this.symbol = args.symbol;
     this.uri = args.uri;
+    this.uriMetadata = {} as URIMetadata;
     this.sellerFeeBasisPoints = args.sellerFeeBasisPoints;
     this.creators = args.creators;
+  }
+}
+
+export class URIMetadata {
+  image!: string;
+  constructor(args: Partial<URIMetadata>) {
+    Object.assign(this, args);
   }
 }
 


### PR DESCRIPTION
For NFT tokens on the Solana network could happen that URI on metadata does not point to the NFT, and instead, it points to a metadata file, so if we detect it is a metadata file, we just go for it.

Solscan offer a button to navigate to the URI metadata

[Solscan Example](https://solscan.io/token/DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263#metadata)

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/1277510/228691270-662d0ec0-cda7-43ee-9131-cb7f928bce3e.png">
