### PR TITLE
feat: add warning when bridging MATIC token from ETH chain

### DIFF
--- a/src/components/Transfer/SourceAssetWarning.tsx
+++ b/src/components/Transfer/SourceAssetWarning.tsx
@@ -1,7 +1,14 @@
-import { ChainId, CHAIN_ID_POLYGON, isEVMChain } from "@certusone/wormhole-sdk";
+import {
+  ChainId,
+  CHAIN_ID_ETH,
+  CHAIN_ID_POLYGON,
+} from "@certusone/wormhole-sdk";
 import { makeStyles, Typography } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
-import { POLYGON_TERRA_WRAPPED_TOKENS } from "../../utils/consts";
+import {
+  ETH_POLYGON_WRAPPED_TOKENS,
+  POLYGON_TERRA_WRAPPED_TOKENS,
+} from "../../utils/consts";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -27,6 +34,19 @@ function PolygonTerraWrappedWarning() {
   );
 }
 
+function EthPolygonWrappedWarning() {
+  const classes = useStyles();
+  return (
+    <Alert severity="warning" variant="outlined" className={classes.alert}>
+      <Typography variant="body1">
+        This is a Polygon Bridge-wrapped asset from Ethereum! Transferring it
+        will result in a double wrapped (Portal-wrapped Polygon-wrapped) asset,
+        which has no liquid markets.
+      </Typography>
+    </Alert>
+  );
+}
+
 export default function SoureAssetWarning({
   sourceChain,
   sourceAsset,
@@ -41,16 +61,24 @@ export default function SoureAssetWarning({
     return null;
   }
 
-  const searchableAddress = isEVMChain(sourceChain)
-    ? sourceAsset.toLowerCase()
-    : sourceAsset;
+  const searchableAddress: string = sourceAsset.toLowerCase();
+
   const showPolygonTerraWrappedWarning =
     sourceChain === CHAIN_ID_POLYGON &&
-    POLYGON_TERRA_WRAPPED_TOKENS.includes(searchableAddress);
+    POLYGON_TERRA_WRAPPED_TOKENS.some(
+      (address) => address.toLowerCase() === searchableAddress
+    );
+
+  const showEthPolygonWrappedWarning =
+    sourceChain === CHAIN_ID_ETH &&
+    ETH_POLYGON_WRAPPED_TOKENS.some(
+      (address) => address.toLowerCase() === searchableAddress
+    );
 
   return (
     <>
-      {showPolygonTerraWrappedWarning ? <PolygonTerraWrappedWarning /> : null}
+      {showPolygonTerraWrappedWarning && <PolygonTerraWrappedWarning />}
+      {showEthPolygonWrappedWarning && <EthPolygonWrappedWarning />}
     </>
   );
 }

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1631,6 +1631,10 @@ export const POLYGON_TERRA_WRAPPED_TOKENS = [
   "0x24834bbec7e39ef42f4a75eaf8e5b6486d3f0e57", // Wrapped LUNA Token
 ];
 
+export const ETH_POLYGON_WRAPPED_TOKENS = [
+  "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0", // Wrapped MATIC Token
+];
+
 export const JUPITER_SWAP_BASE_URL = "https://jup.ag/swap";
 
 export const getIsTransferDisabled = (


### PR DESCRIPTION
# Description 

Display a **warning message** when trying to move `MATIC` token from `ETH` chain

Fixes #83

Ex: 
<img width="817" alt="image" src="https://user-images.githubusercontent.com/25652943/234081739-62fed86e-aebc-4ea6-9ecb-af8cab814b7e.png">

Warning message displayed:
<img width="693" alt="image" src="https://user-images.githubusercontent.com/25652943/234081821-a687e818-e911-4a63-867d-972e2a39d7a1.png">

