### PR TITLE
Solana token selector does not display NFT due an CORS error

### DIFF
--- a/src/contexts/SolanaWalletContext.tsx
+++ b/src/contexts/SolanaWalletContext.tsx
@@ -63,6 +63,7 @@ interface ISolanaContext {
 export const useSolanaWallet = (): ISolanaContext => {
   const wallet = useWallet<SolanaWallet>(CHAIN_ID_SOLANA);
 
+  // Replace here to debug
   const publicKey = useMemo(() => wallet?.getAddress(), [wallet]);
 
   return useMemo(

--- a/src/contexts/SolanaWalletContext.tsx
+++ b/src/contexts/SolanaWalletContext.tsx
@@ -63,7 +63,7 @@ interface ISolanaContext {
 export const useSolanaWallet = (): ISolanaContext => {
   const wallet = useWallet<SolanaWallet>(CHAIN_ID_SOLANA);
 
-  // Replace here to debug
+  //TIP: Replace Solana wallet address here to debug
   const publicKey = useMemo(() => wallet?.getAddress(), [wallet]);
 
   return useMemo(

--- a/src/hooks/useMetaplexData.ts
+++ b/src/hooks/useMetaplexData.ts
@@ -38,9 +38,9 @@ export const getMetaplexData = async (mintAddresses: string[]) => {
               metadataParsed.data.uriMetadata = new URIMetadata(
                 payload as URIMetadata
               );
-            }  
+            }
           } catch (e) {
-            console.error(e);
+            console.error("Error fetching metadata", e);
           }
           return metadataParsed;
         } catch (e) {

--- a/src/hooks/useMetaplexData.ts
+++ b/src/hooks/useMetaplexData.ts
@@ -29,14 +29,18 @@ export const getMetaplexData = async (mintAddresses: string[]) => {
       if (account.data) {
         try {
           const metadataParsed = decodeMetadata(account.data);
-          const response = await fetch(metadataParsed?.data?.uri, {
-            redirect: "follow",
-          });
-          if (!response.headers.get("content-type")?.startsWith("image/")) {
+          try {
+            const response = await fetch(metadataParsed?.data?.uri, {
+              redirect: "follow",
+            });
             const payload = await response.json();
-            metadataParsed.data.uriMetadata = new URIMetadata(
-              payload as URIMetadata
-            );
+            if (!response.headers.get("content-type")?.startsWith("image/")) {
+              metadataParsed.data.uriMetadata = new URIMetadata(
+                payload as URIMetadata
+              );
+            }  
+          } catch (e) {
+            console.error(e);
           }
           return metadataParsed;
         } catch (e) {


### PR DESCRIPTION
Solana token selector does not display NFT due to a CORS error, that produces an undefined for the entire NFT metadata, to avoid the undefined, the inner request was wrapped into a try-catch block, forcing to return a valid object, even if we can not retrieve the metadata to preview the NFT

Before

![image](https://user-images.githubusercontent.com/1277510/235254735-c90241bc-628a-402e-b4d7-f3ba408e8016.png)

After

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/1277510/235254898-3f3aeb0d-0447-4ca4-b74e-a4a8b3887dae.png">

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/1277510/235254667-54733988-ccea-4cc2-9c6e-345b7bfa3657.png">
