### PR TITLE
increase node memory to avoid build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "sed -i '/enableWorkerThreads/d' node_modules/terser-webpack-plugin/dist/index.js && react-app-rewired --max_old_space_size=3072 build",
+    "build": "sed -i '/enableWorkerThreads/d' node_modules/terser-webpack-plugin/dist/index.js && react-app-rewired --max_old_space_size=4096 build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "format": "npx prettier --write ./src"


### PR DESCRIPTION
Time to time build is failing locally due to memory issue, increasing it to avoid future issues locally and at the CI