### PR TITLE
Fix 'add to Metamask' for tBTC on Ethereum

### DIFF
--- a/src/components/Transfer/AddToMetamask.tsx
+++ b/src/components/Transfer/AddToMetamask.tsx
@@ -5,16 +5,13 @@ import { useCallback } from "react";
 import { useSelector } from "react-redux";
 import { useEthereumProvider } from "../../contexts/EthereumProviderContext";
 import {
+  selectTransferSourceChain,
   selectTransferSourceParsedTokenAccount,
   selectTransferTargetAsset,
   selectTransferTargetChain,
   selectTransferThreshold,
 } from "../../store/selectors";
-import {
-  THRESHOLD_GATEWAYS,
-  THRESHOLD_TBTC_CONTRACTS,
-  getEvmChainId,
-} from "../../utils/consts";
+import { THRESHOLD_TBTC_CONTRACTS, getEvmChainId } from "../../utils/consts";
 import {
   ethTokenToParsedTokenAccount,
   getEthereumToken,
@@ -33,12 +30,14 @@ export default function AddToMetamask() {
     selectTransferSourceParsedTokenAccount
   );
   const targetChain = useSelector(selectTransferTargetChain);
+  const sourceChain = useSelector(selectTransferSourceChain);
   const targetAsset = useSelector(selectTransferTargetAsset);
 
   const threshold = useSelector(selectTransferThreshold);
   const isAddingTBTC =
     threshold.isTBTC &&
-    Object.keys(THRESHOLD_GATEWAYS).includes(`${targetChain}`);
+    Object.keys(THRESHOLD_TBTC_CONTRACTS).includes(`${targetChain}`) &&
+    Object.keys(THRESHOLD_TBTC_CONTRACTS).includes(`${sourceChain}`);
   const tbtcAsset = THRESHOLD_TBTC_CONTRACTS[targetChain];
 
   const { provider, signerAddress, evmChainId, wallet } =

--- a/src/hooks/useHandleTransfer.tsx
+++ b/src/hooks/useHandleTransfer.tsx
@@ -319,8 +319,6 @@ async function evm(
     const threshold = thresholdData;
 
     if (threshold?.isTBTC) {
-      console.log("IS TBTC!");
-
       const isEthSource = chainId === CHAIN_ID_ETH;
       const isEthTarget = recipientChain === CHAIN_ID_ETH;
       const isCanonicalSource = Object.keys(THRESHOLD_GATEWAYS).includes(
@@ -352,8 +350,6 @@ async function evm(
           {},
           zeroPad(arrayify(payload), 32)
         );
-
-        console.log({ receipt });
 
         dispatch(
           setTransferTx({
@@ -395,24 +391,9 @@ async function evm(
             signer
           );
 
-          console.log("SEND TBTC?!?");
-
           const amountNormalizeAmount = deNormalizeAmount(
             normalizeAmount(transferAmountParsed, decimals),
             decimals
-          );
-
-          console.log({
-            signer,
-            transferAmountParsed,
-            amountNormalizeAmount,
-            recipientChain,
-            readableTargetAddress,
-          });
-
-          console.log(
-            "zeroPad(arrayify(targetAddress), 32)"
-            // zeroPad(arrayify(targetAddress), 32)
           );
 
           const estimateGas = await L2WormholeGateway.estimateGas.sendTbtc(
@@ -434,8 +415,6 @@ async function evm(
             ...(chainId === CHAIN_ID_POLYGON && { type: 0 }),
           };
 
-          console.log("sendTbtc overrides", { overrides });
-
           const tx = await L2WormholeGateway.sendTbtc(
             amountNormalizeAmount,
             recipientChain,
@@ -446,7 +425,6 @@ async function evm(
           );
 
           const receipt = await tx.wait();
-          console.log({ receipt });
 
           dispatch(
             setTransferTx({
@@ -466,8 +444,6 @@ async function evm(
           const emitterAddress = getEmitterAddressEth(
             getTokenBridgeAddressForChain(chainId)
           );
-
-          console.log({ sequence, emitterAddress });
 
           await fetchSignedVAA(
             chainId,


### PR DESCRIPTION
### Description

The button "Add to Metamask" you see after finishing a transaction, was adding the wrong token if the transaction was a threshold's tBTC transaction with ethereum as the target. Fixed.

Also, removed some console.logs that were not needed.