### PR TITLE
feat: add finality message for polygon chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.17",

--- a/src/components/TransactionProgress.tsx
+++ b/src/components/TransactionProgress.tsx
@@ -152,7 +152,7 @@ export default function TransactionProgress({
               : blockDiff < expectedBlocks
               ? `Waiting for ${blockDiff} / ${expectedBlocks} confirmations on ${CHAINS_BY_ID[chainId].name}...`
               : chainId === CHAIN_ID_POLYGON
-              ? `Waiting for finality on ${CHAINS_BY_ID[chainId].name} which may take up between 30 minutes to 3 hours to complete.`
+              ? `Waiting for finality on ${CHAINS_BY_ID[chainId].name} which may take between 30 minutes to 3 hours to complete.`
               : `Waiting for Wormhole Network consensus...`}
           </Typography>
         </div>

--- a/src/components/TransactionProgress.tsx
+++ b/src/components/TransactionProgress.tsx
@@ -151,6 +151,8 @@ export default function TransactionProgress({
               ? `Waiting for Ethereum finality on Optimism block ${tx?.block}`
               : blockDiff < expectedBlocks
               ? `Waiting for ${blockDiff} / ${expectedBlocks} confirmations on ${CHAINS_BY_ID[chainId].name}...`
+              : chainId === CHAIN_ID_POLYGON
+              ? `Waiting for finality on ${CHAINS_BY_ID[chainId].name} which may take up between 30 minutes to 3 hours to complete.`
               : `Waiting for Wormhole Network consensus...`}
           </Typography>
         </div>


### PR DESCRIPTION
# Description

Fixes #138 

- Add a message for `finality` on the `Polygon` chain transfer

> Waiting for finality on Polygon which may take up between 30 minutes to 3 hours to complete.