### PR TITLE
Add preflight commitment to Solana transaction sending

### DIFF
--- a/src/utils/solana.ts
+++ b/src/utils/solana.ts
@@ -19,6 +19,7 @@ export async function signSendAndConfirm(
     transaction,
     options: {
       commitment: "finalized",
+      preflightCommitment: "confirmed",
     },
   });
   return id;


### PR DESCRIPTION
Since the recent blockhash is fetched using `confirmed` commitment, transaction preflight (simulation) fails if it's sent with `finalized`.