### PR TITLE
#129 - set commitment as confirmed

### DIFF
--- a/src/utils/solana.ts
+++ b/src/utils/solana.ts
@@ -18,7 +18,8 @@ export async function signSendAndConfirm(
   const { id } = await wallet.signAndSendTransaction({
     transaction,
     options: {
-      commitment: "finalized",
+      commitment: "confirmed",
+      preflightCommitment: "confirmed",
     },
   });
   return id;


### PR DESCRIPTION
 Set commitment as confirmed to avoid mixin commitment between tx creation and process

all the Connection instances are created with commitment "confirmed" and we are shipping the transaction with commitment "finalized" which produces a hash not found error.

thank you @vsakos

@see #154 