### PR TITLE
Refactor tBTC flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs/portal-bridge-ui",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.18",
         "@injectivelabs/sdk-ts": "^1.10.72",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.18",

--- a/src/components/Recovery.tsx
+++ b/src/components/Recovery.tsx
@@ -71,11 +71,7 @@ import useIsWalletReady from "../hooks/useIsWalletReady";
 import useRelayersAvailable, { Relayer } from "../hooks/useRelayersAvailable";
 import { COLORS } from "../muiTheme";
 import { setRecoveryVaa as setRecoveryNFTVaa } from "../store/nftSlice";
-import {
-  Threshold,
-  setRecoveryVaa,
-  setThreshold,
-} from "../store/transferSlice";
+import { setRecoveryVaa } from "../store/transferSlice";
 import {
   ALGORAND_HOST,
   ALGORAND_TOKEN_BRIDGE_ID,
@@ -94,8 +90,6 @@ import {
   NEAR_TOKEN_BRIDGE_ACCOUNT,
   XPLA_LCD_CLIENT_CONFIG,
   getWalletAddressNative,
-  THRESHOLD_GATEWAYS,
-  THRESHOLD_TBTC_CONTRACTS,
   CLUSTER,
 } from "../utils/consts";
 import { getSignedVAAWithRetry } from "../utils/getSignedVAAWithRetry";
@@ -571,43 +565,8 @@ export default function Recovery() {
     }
   }, [recoveryParsedVAA, isNFT]);
 
-  const setThresholdData = useCallback(
-    (data: Threshold) => {
-      dispatch(setThreshold(data));
-    },
-    [dispatch]
-  );
-
   useEffect(() => {
     let cancelled = false;
-
-    // THRESHOLD CHECK: if target chain its a canonical chain
-    if (
-      parsedPayload &&
-      Object.keys(THRESHOLD_GATEWAYS).includes(`${parsedPayload?.targetChain}`)
-    ) {
-      const parsedTokenAddress = hexToNativeString(
-        parsedPayload.originAddress,
-        parsedPayload.originChain as ChainId
-      );
-
-      // if is TBTC token
-      if (
-        parsedTokenAddress &&
-        THRESHOLD_TBTC_CONTRACTS[parsedPayload.originChain]?.toLowerCase() ===
-          parsedTokenAddress.toLowerCase()
-      ) {
-        // sets threshold data
-        setThresholdData({
-          isTBTC: true,
-          source: parsedPayload.originChain as ChainId,
-          target: parsedPayload.targetChain as ChainId,
-        });
-      }
-    } else {
-      setThresholdData({ isTBTC: false });
-    }
-
     if (
       parsedPayload &&
       (parsedPayload.targetChain === CHAIN_ID_TERRA2 ||
@@ -663,7 +622,7 @@ export default function Recovery() {
     return () => {
       cancelled = true;
     };
-  }, [parsedPayload, setThresholdData]);
+  }, [parsedPayload]);
 
   const { search } = useLocation();
   const query = useMemo(() => new URLSearchParams(search), [search]);

--- a/src/components/Transfer/AddToMetamask.tsx
+++ b/src/components/Transfer/AddToMetamask.tsx
@@ -9,7 +9,7 @@ import {
   selectTransferSourceParsedTokenAccount,
   selectTransferTargetAsset,
   selectTransferTargetChain,
-  selectTransferThreshold,
+  selectTransferIsTBTC,
 } from "../../store/selectors";
 import { THRESHOLD_TBTC_CONTRACTS, getEvmChainId } from "../../utils/consts";
 import {
@@ -33,11 +33,11 @@ export default function AddToMetamask() {
   const sourceChain = useSelector(selectTransferSourceChain);
   const targetAsset = useSelector(selectTransferTargetAsset);
 
-  const threshold = useSelector(selectTransferThreshold);
+  const isTBTC = useSelector(selectTransferIsTBTC);
   const isAddingTBTC =
-    threshold.isTBTC &&
-    Object.keys(THRESHOLD_TBTC_CONTRACTS).includes(`${targetChain}`) &&
-    Object.keys(THRESHOLD_TBTC_CONTRACTS).includes(`${sourceChain}`);
+    isTBTC &&
+    THRESHOLD_TBTC_CONTRACTS[targetChain] &&
+    THRESHOLD_TBTC_CONTRACTS[sourceChain];
   const tbtcAsset = THRESHOLD_TBTC_CONTRACTS[targetChain];
 
   const { provider, signerAddress, evmChainId, wallet } =

--- a/src/components/Transfer/SendConfirmationDialog.tsx
+++ b/src/components/Transfer/SendConfirmationDialog.tsx
@@ -14,9 +14,14 @@ import {
   selectTransferOriginChain,
   selectTransferSourceChain,
   selectTransferSourceParsedTokenAccount,
-  selectTransferThreshold,
+  selectTransferIsTBTC,
 } from "../../store/selectors";
-import { CHAINS_BY_ID, CLUSTER, MULTI_CHAIN_TOKENS } from "../../utils/consts";
+import {
+  CHAINS_BY_ID,
+  CLUSTER,
+  MULTI_CHAIN_TOKENS,
+  THRESHOLD_TBTC_CONTRACTS,
+} from "../../utils/consts";
 import SmartAddress from "../SmartAddress";
 import SolanaTPSWarning from "../SolanaTPSWarning";
 import { useTargetInfo } from "./Target";
@@ -31,7 +36,7 @@ function SendConfirmationContent({
   onClose: () => void;
   onClick: () => void;
 }) {
-  const { isTBTC } = useSelector(selectTransferThreshold);
+  const isTBTC = useSelector(selectTransferIsTBTC);
   const sourceChain = useSelector(selectTransferSourceChain);
   const sourceParsedTokenAccount = useSelector(
     selectTransferSourceParsedTokenAccount
@@ -128,7 +133,9 @@ function SendConfirmationContent({
           originChain={originChain}
           targetAsset={targetAsset ?? undefined}
           targetChain={targetChain}
-          isTBTC={isTBTC}
+          showCanonicalTbtcMessage={
+            isTBTC && THRESHOLD_TBTC_CONTRACTS[targetChain]
+          }
         />
         {sourceChain === CHAIN_ID_SOLANA && CLUSTER === "mainnet" && (
           <SolanaTPSWarning />

--- a/src/components/Transfer/TokenWarning.tsx
+++ b/src/components/Transfer/TokenWarning.tsx
@@ -159,22 +159,20 @@ export default function TokenWarning({
   originChain,
   targetChain,
   targetAsset,
-  isTBTC = false,
+  showCanonicalTbtcMessage = false,
 }: {
   sourceChain?: ChainId;
   sourceAsset?: string;
   originChain?: ChainId;
   targetChain?: ChainId;
   targetAsset?: string;
-  isTBTC?: boolean;
+  showCanonicalTbtcMessage?: boolean;
 }) {
   if (
     !(originChain && targetChain && targetAsset && sourceChain && sourceAsset)
   ) {
     return null;
   }
-
-  const isCanonical: boolean = isTBTC;
 
   const searchableAddress = isEVMChain(sourceChain)
     ? sourceAsset.toLowerCase()
@@ -193,12 +191,12 @@ export default function TokenWarning({
     !isMultiChain &&
     isWormholeWrapped &&
     targetChain !== CHAIN_ID_APTOS &&
-    isCanonical;
+    showCanonicalTbtcMessage;
   const showWrappedWarning =
     !isMultiChain &&
     isWormholeWrapped &&
     targetChain !== CHAIN_ID_APTOS &&
-    !isCanonical; //Multichain warning is more important
+    !showCanonicalTbtcMessage; //Multichain warning is more important
   const showRewardsWarning = isRewardsToken;
   const showLiquidityWarning = shouldShowLiquidityWarning(
     sourceChain,

--- a/src/hooks/useCheckIfWormholeWrapped.ts
+++ b/src/hooks/useCheckIfWormholeWrapped.ts
@@ -18,6 +18,7 @@ import {
   getOriginalAssetInjective,
   CHAIN_ID_SUI,
   getOriginalAssetSui,
+  CHAIN_ID_ETH,
 } from "@certusone/wormhole-sdk";
 import {
   getOriginalAssetEth as getOriginalAssetEthNFT,
@@ -54,6 +55,7 @@ import {
   SOL_NFT_BRIDGE_ADDRESS,
   SOL_TOKEN_BRIDGE_ADDRESS,
   XPLA_LCD_CLIENT_CONFIG,
+  THRESHOLD_TBTC_CONTRACTS,
 } from "../utils/consts";
 import { getOriginalAssetNear, makeNearAccount } from "../utils/near";
 import { LCDClient as XplaLCDClient } from "@xpla/xpla.js";
@@ -123,6 +125,27 @@ function useCheckIfWormholeWrapped(nft?: boolean) {
                 sourceChain
               ))
         );
+
+        // check for tBTC on canonical chains, make their origin be eth-wrapped-tbtc
+        if (
+          !cancelled &&
+          sourceChain !== CHAIN_ID_ETH &&
+          THRESHOLD_TBTC_CONTRACTS[sourceChain]?.toLowerCase() ===
+            sourceAsset?.toLowerCase()
+        ) {
+          console.log("selected tBTC on canonical chain");
+          dispatch(
+            setSourceWormholeWrappedInfo({
+              isWrapped: true,
+              chainId: CHAIN_ID_ETH,
+              assetAddress: THRESHOLD_TBTC_CONTRACTS[CHAIN_ID_ETH].slice(
+                2
+              ).padStart(64, "0"),
+            })
+          );
+          return;
+        }
+
         if (!cancelled) {
           dispatch(setSourceWormholeWrappedInfo(wrappedInfo));
         }

--- a/src/hooks/useCheckIfWormholeWrapped.ts
+++ b/src/hooks/useCheckIfWormholeWrapped.ts
@@ -56,6 +56,7 @@ import {
   SOL_TOKEN_BRIDGE_ADDRESS,
   XPLA_LCD_CLIENT_CONFIG,
   THRESHOLD_TBTC_CONTRACTS,
+  TBTC_ASSET_ADDRESS,
 } from "../utils/consts";
 import { getOriginalAssetNear, makeNearAccount } from "../utils/near";
 import { LCDClient as XplaLCDClient } from "@xpla/xpla.js";
@@ -138,9 +139,7 @@ function useCheckIfWormholeWrapped(nft?: boolean) {
             setSourceWormholeWrappedInfo({
               isWrapped: true,
               chainId: CHAIN_ID_ETH,
-              assetAddress: THRESHOLD_TBTC_CONTRACTS[CHAIN_ID_ETH].slice(
-                2
-              ).padStart(64, "0"),
+              assetAddress: TBTC_ASSET_ADDRESS,
             })
           );
           return;

--- a/src/hooks/useFetchTargetAsset.ts
+++ b/src/hooks/useFetchTargetAsset.ts
@@ -53,6 +53,7 @@ import {
   selectNFTOriginTokenId,
   selectNFTTargetChain,
   selectTransferIsSourceAssetWormholeWrapped,
+  selectTransferIsTBTC,
   selectTransferOriginAsset,
   selectTransferOriginChain,
   selectTransferTargetChain,
@@ -72,6 +73,8 @@ import {
   NATIVE_NEAR_WH_ADDRESS,
   NATIVE_NEAR_PLACEHOLDER,
   XPLA_LCD_CLIENT_CONFIG,
+  THRESHOLD_TBTC_CONTRACTS,
+  THRESHOLD_GATEWAYS,
 } from "../utils/consts";
 import {
   getForeignAssetNear,
@@ -101,6 +104,7 @@ function useFetchTargetAsset(nft?: boolean) {
   const targetChain = useSelector(
     nft ? selectNFTTargetChain : selectTransferTargetChain
   );
+  const isTBTC = useSelector(selectTransferIsTBTC);
   const setTargetAsset = nft ? setNFTTargetAsset : setTransferTargetAsset;
   const { provider, evmChainId } = useEthereumProvider(targetChain);
   const correctEvmNetwork = getEvmChainId(targetChain);
@@ -305,6 +309,17 @@ function useFetchTargetAsset(nft?: boolean) {
         if (!cancelled) {
           setArgs();
         }
+        return;
+      }
+      if (isTBTC && THRESHOLD_GATEWAYS[targetChain]) {
+        dispatch(
+          setTargetAsset(
+            receiveDataWrapper({
+              doesExist: true,
+              address: THRESHOLD_TBTC_CONTRACTS[targetChain],
+            })
+          )
+        );
         return;
       }
       if (
@@ -656,6 +671,7 @@ function useFetchTargetAsset(nft?: boolean) {
     argsMatchLastSuccess,
     setArgs,
     nearAccountId,
+    isTBTC,
   ]);
 }
 

--- a/src/hooks/useFetchTargetAsset.ts
+++ b/src/hooks/useFetchTargetAsset.ts
@@ -313,7 +313,7 @@ function useFetchTargetAsset(nft?: boolean) {
         }
         return;
       }
-      if (isTBTC && THRESHOLD_GATEWAYS[targetChain] && activeStep < 2) {
+      if (isTBTC && THRESHOLD_GATEWAYS[targetChain] && !cancelled) {
         dispatch(
           setTargetAsset(
             receiveDataWrapper({
@@ -322,6 +322,7 @@ function useFetchTargetAsset(nft?: boolean) {
             })
           )
         );
+        setArgs();
         return;
       }
       if (

--- a/src/hooks/useFetchTargetAsset.ts
+++ b/src/hooks/useFetchTargetAsset.ts
@@ -52,6 +52,7 @@ import {
   selectNFTOriginChain,
   selectNFTOriginTokenId,
   selectNFTTargetChain,
+  selectTransferActiveStep,
   selectTransferIsSourceAssetWormholeWrapped,
   selectTransferIsTBTC,
   selectTransferOriginAsset,
@@ -105,6 +106,7 @@ function useFetchTargetAsset(nft?: boolean) {
     nft ? selectNFTTargetChain : selectTransferTargetChain
   );
   const isTBTC = useSelector(selectTransferIsTBTC);
+  const activeStep = useSelector(selectTransferActiveStep);
   const setTargetAsset = nft ? setNFTTargetAsset : setTransferTargetAsset;
   const { provider, evmChainId } = useEthereumProvider(targetChain);
   const correctEvmNetwork = getEvmChainId(targetChain);
@@ -311,7 +313,7 @@ function useFetchTargetAsset(nft?: boolean) {
         }
         return;
       }
-      if (isTBTC && THRESHOLD_GATEWAYS[targetChain]) {
+      if (isTBTC && THRESHOLD_GATEWAYS[targetChain] && activeStep < 2) {
         dispatch(
           setTargetAsset(
             receiveDataWrapper({
@@ -672,6 +674,7 @@ function useFetchTargetAsset(nft?: boolean) {
     setArgs,
     nearAccountId,
     isTBTC,
+    activeStep,
   ]);
 }
 

--- a/src/hooks/useHandleRedeem.tsx
+++ b/src/hooks/useHandleRedeem.tsx
@@ -41,9 +41,9 @@ import {
   selectTerraFeeDenom,
   selectTransferIsRedeeming,
   selectTransferTargetChain,
-  selectTransferThreshold,
+  selectTransferIsTBTC,
 } from "../store/selectors";
-import { Threshold, setIsRedeeming, setRedeemTx } from "../store/transferSlice";
+import { setIsRedeeming, setRedeemTx } from "../store/transferSlice";
 import { signSendAndConfirmAlgorand } from "../utils/algorand";
 import {
   getAptosClient,
@@ -164,55 +164,39 @@ async function evm(
   signedVAA: Uint8Array,
   isNative: boolean,
   chainId: ChainId,
-  threshold?: Threshold
+  isTBTC?: boolean
 ) {
   dispatch(setIsRedeeming(true));
 
   try {
     let receipt;
 
-    // THRESHOLD tBTC FLOW
-    if (threshold?.isTBTC) {
-      const isCanonicalTarget = Object.keys(THRESHOLD_GATEWAYS).includes(
-        `${chainId}`
+    const isCanonicalTarget = !!THRESHOLD_GATEWAYS[chainId];
+    if (isTBTC && isCanonicalTarget) {
+      console.log("redeem tbtc on canonical");
+      const targetAddress = THRESHOLD_GATEWAYS[chainId];
+      const L2WormholeGateway = new Contract(
+        targetAddress,
+        ThresholdL2WormholeGateway,
+        signer
       );
 
-      // tBTC Flow canonical target
-      if (isCanonicalTarget) {
-        const targetAddress = THRESHOLD_GATEWAYS[chainId];
-        const L2WormholeGateway = new Contract(
-          targetAddress,
-          ThresholdL2WormholeGateway,
-          signer
-        );
+      const estimateGas = await L2WormholeGateway.estimateGas.receiveTbtc(
+        signedVAA
+      );
 
-        const estimateGas = await L2WormholeGateway.estimateGas.receiveTbtc(
-          signedVAA
-        );
+      // We increase the gas limit estimation here by a factor of 10% to account for some faulty public JSON-RPC endpoints.
+      const gasLimit = estimateGas.mul(1100).div(1000);
+      const overrides = {
+        gasLimit,
+        // We use the legacy tx envelope here to avoid triggering gas price autodetection using EIP1559 for polygon.
+        // EIP1559 is not actually implemented in polygon. The node is only API compatible but this breaks some clients
+        // like ethers when choosing fees automatically.
+        ...(chainId === CHAIN_ID_POLYGON && { type: 0 }),
+      };
 
-        // We increase the gas limit estimation here by a factor of 10% to account for
-        // some faulty public JSON-RPC endpoints.
-        const gasLimit = estimateGas.mul(1100).div(1000);
-        const overrides = {
-          gasLimit,
-          // We use the legacy tx envelope here to avoid triggering gas price autodetection using EIP1559 for polygon.
-          // EIP1559 is not actually implemented in polygon. The node is only API compatible but this breaks some clients
-          // like ethers when choosing fees automatically.
-          ...(chainId === CHAIN_ID_POLYGON && { type: 0 }),
-        };
-
-        const tx = await L2WormholeGateway.receiveTbtc(signedVAA, overrides);
-        receipt = await tx.wait();
-      }
-      // tBTC Flow ethereum target
-      else {
-        receipt = await redeemOnEth(
-          getTokenBridgeAddressForChain(chainId),
-          signer,
-          signedVAA,
-          {}
-        );
-      }
+      const tx = await L2WormholeGateway.receiveTbtc(signedVAA, overrides);
+      receipt = await tx.wait();
     }
     // REGULAR PORTAL BRIDGE FLOW
     else {
@@ -481,7 +465,7 @@ export function useHandleRedeem() {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
   const targetChain = useSelector(selectTransferTargetChain);
-  const threshold = useSelector(selectTransferThreshold);
+  const isTBTC = useSelector(selectTransferIsTBTC);
 
   const { publicKey: solPK, wallet: solanaWallet } = useSolanaWallet();
   const { signer } = useEthereumProvider(targetChain);
@@ -504,7 +488,7 @@ export function useHandleRedeem() {
         signedVAA,
         false,
         targetChain,
-        threshold
+        isTBTC
       );
     } else if (
       targetChain === CHAIN_ID_SOLANA &&
@@ -570,7 +554,7 @@ export function useHandleRedeem() {
     suiWallet,
     dispatch,
     enqueueSnackbar,
-    threshold,
+    isTBTC,
     terraFeeDenom,
     aptosWallet,
     algoWallet,

--- a/src/hooks/useHandleTransfer.tsx
+++ b/src/hooks/useHandleTransfer.tsx
@@ -336,15 +336,6 @@ async function evm(
     if (isTBTC && THRESHOLD_GATEWAYS[chainId]) {
       const sourceAddress = THRESHOLD_GATEWAYS[chainId].toLowerCase();
 
-      console.log(
-        "Canonical to ",
-        THRESHOLD_GATEWAYS[recipientChain]
-          ? "Canonical"
-          : recipientChain === CHAIN_ID_ETH
-          ? "ETH"
-          : "Non-Canonical"
-      );
-
       const L2WormholeGateway = new Contract(
         sourceAddress,
         ThresholdL2WormholeGateway,
@@ -386,8 +377,6 @@ async function evm(
 
       receipt = await tx.wait();
     } else {
-      console.log("Regular flow! isTBTC?", isTBTC);
-
       // Klaytn requires specifying gasPrice
       const overrides =
         chainId === CHAIN_ID_KLAYTN

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -8,7 +8,7 @@ import {
 import { ethers } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { RootState } from ".";
-import { THRESHOLD_TBTC_CONTRACTS } from "../utils/consts";
+import { TBTC_ASSET_ADDRESS } from "../utils/consts";
 
 /*
  * Attest
@@ -176,9 +176,7 @@ export const selectTransferIsTBTC = (state: RootState) => {
   return (
     state.transfer.originChain === CHAIN_ID_ETH &&
     state.transfer.originAsset?.toLowerCase() ===
-      THRESHOLD_TBTC_CONTRACTS[CHAIN_ID_ETH].slice(2)
-        .padStart(64, "0")
-        ?.toLowerCase()
+      TBTC_ASSET_ADDRESS?.toLowerCase()
   );
 };
 export const selectTransferIsSourceAssetWormholeWrapped = (state: RootState) =>

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,5 +1,6 @@
 import {
   CHAIN_ID_ACALA,
+  CHAIN_ID_ETH,
   CHAIN_ID_KARURA,
   CHAIN_ID_SOLANA,
   isEVMChain,
@@ -7,6 +8,7 @@ import {
 import { ethers } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { RootState } from ".";
+import { THRESHOLD_TBTC_CONTRACTS } from "../utils/consts";
 
 /*
  * Attest
@@ -170,8 +172,14 @@ export const selectTransferSourceChain = (state: RootState) =>
 export const selectTransferSourceAsset = (state: RootState) => {
   return state.transfer.sourceParsedTokenAccount?.mintKey || undefined;
 };
-export const selectTransferThreshold = (state: RootState) => {
-  return state.transfer.threshold;
+export const selectTransferIsTBTC = (state: RootState) => {
+  return (
+    state.transfer.originChain === CHAIN_ID_ETH &&
+    state.transfer.originAsset?.toLowerCase() ===
+      THRESHOLD_TBTC_CONTRACTS[CHAIN_ID_ETH].slice(2)
+        .padStart(64, "0")
+        ?.toLowerCase()
+  );
 };
 export const selectTransferIsSourceAssetWormholeWrapped = (state: RootState) =>
   state.transfer.isSourceAssetWormholeWrapped;

--- a/src/store/transferSlice.ts
+++ b/src/store/transferSlice.ts
@@ -37,12 +37,6 @@ export interface Transaction {
   block: number;
 }
 
-export interface Threshold {
-  isTBTC: boolean;
-  source?: ChainId | undefined;
-  target?: ChainId | undefined;
-}
-
 export interface TransferState {
   activeStep: Steps;
   sourceChain: ChainId;
@@ -60,7 +54,6 @@ export interface TransferState {
   transferTx: Transaction | undefined;
   signedVAAHex: string | undefined;
   isSending: boolean;
-  threshold: Threshold;
   isVAAPending: boolean;
   isRedeeming: boolean;
   redeemTx: Transaction | undefined;
@@ -89,9 +82,6 @@ const initialState: TransferState = {
   transferTx: undefined,
   signedVAAHex: undefined,
   isSending: false,
-  threshold: {
-    isTBTC: false,
-  },
   isVAAPending: false,
   isRedeeming: false,
   redeemTx: undefined,
@@ -232,9 +222,6 @@ export const transferSlice = createSlice({
     setIsSending: (state, action: PayloadAction<boolean>) => {
       state.isSending = action.payload;
     },
-    setThreshold: (state, action: PayloadAction<Threshold>) => {
-      state.threshold = action.payload;
-    },
     setIsVAAPending: (state, action: PayloadAction<boolean>) => {
       state.isVAAPending = action.payload;
     },
@@ -344,7 +331,6 @@ export const {
   setTransferTx,
   setSignedVAAHex,
   setIsSending,
-  setThreshold,
   setIsVAAPending,
   setIsRedeeming,
   setRedeemTx,

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -429,6 +429,8 @@ export const THRESHOLD_TBTC_CONTRACTS: any = {
       : "0x85727F4725A4B2834e00Db1AA8e1b843a188162F",
 };
 
+// prettier-ignore
+export const TBTC_ASSET_ADDRESS = THRESHOLD_TBTC_CONTRACTS[CHAIN_ID_ETH].slice(2).padStart(64, "0");
 export const THRESHOLD_ARBITER_FEE = 0;
 export const THRESHOLD_NONCE = 0;
 


### PR DESCRIPTION
### Description

This PR implements a refactor on the Threshold tBTC flow.

Before, we were allowing multiple wrapped tBTCs token to get generated: wTBTC-Eth, wTBTC-Opt, wTBTC-Arb and wTBTC-Pol. Those tokens were not 100% interchangeable between all the chains. It was possible to end up with double wrapped tokens.

Now, the only wrapped asset that is going to circulate on portal bridge is the wTBTC-Eth. If the source chain it's a threshold-supported chain like Optimism, and from there you send canonical tBTC to, for example, Avalanche. Instead of receiving wTBTC-Opt you will receive wTBTC-Eth. And you can swap that wTBTC-Eth for canonical tBTCs on any supported chain (be Optimism or any other)

Basically, you can send your tBTC from any chain to any other chain and you should never see two assets nor have any double-wrapped asset.