### PR TITLE
terra parity upgrade fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs/portal-bridge-ui",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.20",
         "@injectivelabs/sdk-ts": "^1.10.72",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.37",
+  "version": "0.1.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs/portal-bridge-ui",
-      "version": "0.1.37",
+      "version": "0.1.39",
       "dependencies": {
-        "@certusone/wormhole-sdk": "^0.9.18",
+        "@certusone/wormhole-sdk": "^0.9.20",
         "@injectivelabs/sdk-ts": "^1.10.72",
         "@injectivelabs/ts-types": "^1.10.4",
         "@injectivelabs/wallet-ts": "^1.10.51",
@@ -36,6 +36,7 @@
         "@solana/wallet-adapter-react-ui": "^0.9.5",
         "@solana/wallet-adapter-wallets": "^0.19.5",
         "@solana/web3.js": "^1.35.1",
+        "@terra-money/terra.js": "^3.1.9",
         "@terra-money/wallet-provider": "^3.9.4",
         "@walletconnect/web3-provider": "^1.7.8",
         "@xlabs-libs/wallet-aggregator-algorand": "0.0.1-alpha.16",
@@ -2078,21 +2079,18 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.18.tgz",
-      "integrity": "sha512-0YtrdZmjfiUHL78Yr4FA59ywb+pIevbID/TJpJTp/EKWqm/v+9PS4YBMBEtjpDZR/PSqe6hB8MasF38fUjMGtQ==",
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.20.tgz",
+      "integrity": "sha512-sHmvqK0FYUa+NCO+kqPQ7CkPrFnl40pGQ8pmp3KW/xn3ECz7ECA3M1/07UvMNzcifbHwM1nmO0QhkEAjREB8wg==",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.6",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
-        "@injectivelabs/networks": "1.10.12",
-        "@injectivelabs/sdk-ts": "1.10.72",
-        "@injectivelabs/utils": "1.10.12",
         "@mysten/sui.js": "0.32.2",
         "@project-serum/anchor": "^0.25.0",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.66.2",
-        "@terra-money/terra.js": "^3.1.3",
+        "@terra-money/terra.js": "3.1.9",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^1.15.0",
         "aptos": "1.5.0",
@@ -2103,6 +2101,11 @@
         "elliptic": "^6.5.4",
         "js-base64": "^3.6.1",
         "near-api-js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "@injectivelabs/networks": "1.10.12",
+        "@injectivelabs/sdk-ts": "1.10.72",
+        "@injectivelabs/utils": "1.10.12"
       }
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
@@ -2167,6 +2170,7 @@
       "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.10.12.tgz",
       "integrity": "sha512-tTHyLls1Nik5QTs/S03qqG2y/ITvNwI8CJOQbMmmsr1CL2CdjJBtzRYn9Dyx2p8XgzRFf9hmlybpe20tq9O3SA==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "@injectivelabs/exceptions": "^1.10.12",
         "@injectivelabs/ts-types": "^1.10.12",
@@ -2180,6 +2184,7 @@
       "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.10.12.tgz",
       "integrity": "sha512-Z/qeZ9jwhqpreXFNiox6NrXLiMyhvMEd79RWMZ9lVOLjTeXRTUh/Vl7ry7KBE2OypsPPTMUP+k7Dhsn0ufFwgw==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
@@ -2364,6 +2369,28 @@
       "dependencies": {
         "@chainsafe/as-sha256": "^0.4.1",
         "@chainsafe/persistent-merkle-tree": "^0.6.1"
+      }
+    },
+    "node_modules/@classic-terra/terra.proto": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@classic-terra/terra.proto/-/terra.proto-1.1.0.tgz",
+      "integrity": "sha512-bYhQG5LUaGF0KPRY9hYT/HEcd1QExZPQd6zLV/rQkCe/eDxfwFRLzZHpaaAdfWoAAZjsRWqJbUCqCg7gXBbJpw==",
+      "dependencies": {
+        "@improbable-eng/grpc-web": "^0.14.1",
+        "google-protobuf": "^3.17.3",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
+    "node_modules/@classic-terra/terra.proto/node_modules/@improbable-eng/grpc-web": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.14.1.tgz",
+      "integrity": "sha512-XaIYuunepPxoiGVLLHmlnVminUGzBTnXr8Wv7khzmLWbNw4TCwJKX09GSMJlKhu/TRk6gms0ySFxewaETSBqgw==",
+      "dependencies": {
+        "browser-headers": "^0.4.1"
+      },
+      "peerDependencies": {
+        "google-protobuf": "^3.14.0"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -8653,11 +8680,11 @@
       }
     },
     "node_modules/@terra-money/terra.js": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.7.tgz",
-      "integrity": "sha512-z7NwVI1gh0846pgQJaPHya6SRKLd/dHWR5UwWG6T2Pf24I2EjCo8YY5Fay30pCvHTYA2NBFgnWfXEZ/31TfB1Q==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.9.tgz",
+      "integrity": "sha512-JulSvOHLM56fL7s+cIjIbZeWPBluq883X1soWxA4TG5rKkDythT/DHeLXr3jP5Ld/26VENPSg6lNvK7cEYKpiw==",
       "dependencies": {
-        "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
+        "@classic-terra/terra.proto": "^1.1.0",
         "@terra-money/terra.proto": "^2.1.0",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
@@ -40526,9 +40553,9 @@
       }
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.18.tgz",
-      "integrity": "sha512-0YtrdZmjfiUHL78Yr4FA59ywb+pIevbID/TJpJTp/EKWqm/v+9PS4YBMBEtjpDZR/PSqe6hB8MasF38fUjMGtQ==",
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.20.tgz",
+      "integrity": "sha512-sHmvqK0FYUa+NCO+kqPQ7CkPrFnl40pGQ8pmp3KW/xn3ECz7ECA3M1/07UvMNzcifbHwM1nmO0QhkEAjREB8wg==",
       "requires": {
         "@certusone/wormhole-sdk-proto-web": "0.0.6",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -40540,7 +40567,7 @@
         "@project-serum/anchor": "^0.25.0",
         "@solana/spl-token": "^0.3.5",
         "@solana/web3.js": "^1.66.2",
-        "@terra-money/terra.js": "^3.1.3",
+        "@terra-money/terra.js": "3.1.9",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^1.15.0",
         "aptos": "1.5.0",
@@ -40557,6 +40584,7 @@
           "version": "1.10.12",
           "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.10.12.tgz",
           "integrity": "sha512-tTHyLls1Nik5QTs/S03qqG2y/ITvNwI8CJOQbMmmsr1CL2CdjJBtzRYn9Dyx2p8XgzRFf9hmlybpe20tq9O3SA==",
+          "optional": true,
           "requires": {
             "@injectivelabs/exceptions": "^1.10.12",
             "@injectivelabs/ts-types": "^1.10.12",
@@ -40569,6 +40597,7 @@
           "version": "1.10.12",
           "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.10.12.tgz",
           "integrity": "sha512-Z/qeZ9jwhqpreXFNiox6NrXLiMyhvMEd79RWMZ9lVOLjTeXRTUh/Vl7ry7KBE2OypsPPTMUP+k7Dhsn0ufFwgw==",
+          "optional": true,
           "requires": {
             "link-module-alias": "^1.2.0",
             "shx": "^0.3.2"
@@ -40757,6 +40786,27 @@
       "requires": {
         "@chainsafe/as-sha256": "^0.4.1",
         "@chainsafe/persistent-merkle-tree": "^0.6.1"
+      }
+    },
+    "@classic-terra/terra.proto": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@classic-terra/terra.proto/-/terra.proto-1.1.0.tgz",
+      "integrity": "sha512-bYhQG5LUaGF0KPRY9hYT/HEcd1QExZPQd6zLV/rQkCe/eDxfwFRLzZHpaaAdfWoAAZjsRWqJbUCqCg7gXBbJpw==",
+      "requires": {
+        "@improbable-eng/grpc-web": "^0.14.1",
+        "google-protobuf": "^3.17.3",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      },
+      "dependencies": {
+        "@improbable-eng/grpc-web": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.14.1.tgz",
+          "integrity": "sha512-XaIYuunepPxoiGVLLHmlnVminUGzBTnXr8Wv7khzmLWbNw4TCwJKX09GSMJlKhu/TRk6gms0ySFxewaETSBqgw==",
+          "requires": {
+            "browser-headers": "^0.4.1"
+          }
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -45128,11 +45178,11 @@
       }
     },
     "@terra-money/terra.js": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.7.tgz",
-      "integrity": "sha512-z7NwVI1gh0846pgQJaPHya6SRKLd/dHWR5UwWG6T2Pf24I2EjCo8YY5Fay30pCvHTYA2NBFgnWfXEZ/31TfB1Q==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-3.1.9.tgz",
+      "integrity": "sha512-JulSvOHLM56fL7s+cIjIbZeWPBluq883X1soWxA4TG5rKkDythT/DHeLXr3jP5Ld/26VENPSg6lNvK7cEYKpiw==",
       "requires": {
-        "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
+        "@classic-terra/terra.proto": "^1.1.0",
         "@terra-money/terra.proto": "^2.1.0",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "private": true,
   "dependencies": {
-    "@certusone/wormhole-sdk": "^0.9.18",
+    "@certusone/wormhole-sdk": "^0.9.20",
     "@injectivelabs/sdk-ts": "^1.10.72",
     "@injectivelabs/ts-types": "^1.10.4",
     "@injectivelabs/wallet-ts": "^1.10.51",
@@ -31,6 +31,7 @@
     "@solana/wallet-adapter-react-ui": "^0.9.5",
     "@solana/wallet-adapter-wallets": "^0.19.5",
     "@solana/web3.js": "^1.35.1",
+    "@terra-money/terra.js": "^3.1.9",
     "@terra-money/wallet-provider": "^3.9.4",
     "@walletconnect/web3-provider": "^1.7.8",
     "@xlabs-libs/wallet-aggregator-algorand": "0.0.1-alpha.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "private": true,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.20",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -654,7 +654,7 @@ export const SOLANA_HOST = process.env.REACT_APP_SOLANA_API_URL
   : "http://localhost:8899";
 
 export const getTerraConfig = (chainId: TerraChainId) => {
-  const isClassic = chainId === CHAIN_ID_TERRA;
+  const isClassic = false;
   return CLUSTER === "mainnet"
     ? {
         URL:


### PR DESCRIPTION
Fixes RPC errors when transferring tokens to/from terra classic. Native terra classic tokens still can't be redeemed until the contract is upgraded to support it.