### PR TITLE
Use algorand indexer to retrieve past transactions

### DIFF
--- a/src/components/Recovery.tsx
+++ b/src/components/Recovery.tsx
@@ -223,9 +223,7 @@ async function algo(tx: string, enqueueSnackbar: any) {
     // transform the object to match the format expected by parseSequenceFromLogAlgorand
     confirmedTxInfo["inner-txns"] = confirmedTxInfo["inner-txns"].map(
       (txn: any) => ({
-        // TODO: seems to be little different from the format returned by algodClient.pendingTransactionInformation(tx)
-        // so there may be another encoding step to do here
-        logs: [Buffer.from(txn["logs"], "base64")],
+        logs: [Buffer.from(txn["logs"][0], "base64")],
       })
     );
     const sequence = parseSequenceFromLogAlgorand(confirmedTxInfo);

--- a/src/components/Recovery.tsx
+++ b/src/components/Recovery.tsx
@@ -220,11 +220,19 @@ async function algo(tx: string, enqueueSnackbar: any) {
     if (!confirmedTxInfo) {
       throw new Error("Transaction not found or not confirmed");
     }
+    if (!confirmedTxInfo["inner-txns"]) {
+      throw new Error("Source Tx does not refer to a valid bridge transaction");
+    }
     // transform the object to match the format expected by parseSequenceFromLogAlgorand
     confirmedTxInfo["inner-txns"] = confirmedTxInfo["inner-txns"].map(
-      (txn: any) => ({
-        logs: [Buffer.from(txn["logs"][0], "base64")],
-      })
+      (innerTxn: any) => {
+        return {
+          ...innerTxn,
+          logs: innerTxn["logs"]?.[0]
+            ? [Buffer.from(innerTxn["logs"][0], "base64")]
+            : undefined,
+        };
+      }
     );
     const sequence = parseSequenceFromLogAlgorand(confirmedTxInfo);
     if (!sequence) {

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -784,6 +784,25 @@ export const ALGORAND_HOST =
         algodServer: "http://localhost",
         algodPort: "4001",
       };
+export const ALGORAND_INDEXER =
+  CLUSTER === "mainnet"
+    ? {
+        token: "",
+        server: "https://mainnet-idx.algonode.cloud",
+        port: "443",
+      }
+    : CLUSTER === "testnet"
+    ? {
+        token: "",
+        server: "https://testnet-idx.algonode.cloud",
+        port: "443",
+      }
+    : {
+        token:
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        server: "http://localhost",
+        port: "8980",
+      };
 export const KARURA_HOST =
   CLUSTER === "mainnet"
     ? "https://eth-rpc-karura.aca-api.network/"


### PR DESCRIPTION
Given the current throughput of Algorand, users are unable to redeem transactions that were made more than approximately 55 minutes ago. This limitation arises from the use of the `pendingTransactionInformation` endpoint in the Algorand client, which only supports requests for transactions up to 1000 blocks in the past. To retrieve any transaction beyond this limit, we need to utilize the Algorand indexer.

To solve this problem, I made the necessary request via the indexer. However, the transaction encoding differs between the two endpoints, so I performed a transformation of the latter to make it compatible with the parameter required by `parseSequenceFromLogAlgorand`.
