### PR TITLE
#124 - Token information box should not be displayed when user disconnects the wallet

### DIFF
--- a/src/components/Transfer/Source.tsx
+++ b/src/components/Transfer/Source.tsx
@@ -110,7 +110,8 @@ function Source() {
   const error = useSelector(selectTransferSourceError);
   const isSourceComplete = useSelector(selectTransferIsSourceComplete);
   const shouldLockFields = useSelector(selectTransferShouldLockFields);
-  const { isReady, statusMessage, walletAddress } = useIsWalletReady(sourceChain);
+  const { isReady, statusMessage, walletAddress } =
+    useIsWalletReady(sourceChain);
   const isTransferLimited = useIsTransferLimited();
   const handleMigrationClick = useCallback(() => {
     if (sourceChain === CHAIN_ID_ETH) {
@@ -226,7 +227,7 @@ function Source() {
         </div>
       </div>
       <KeyAndBalance chainId={sourceChain} />
-      {((isReady || uiAmountString) && !!walletAddress) ? (
+      {(isReady || uiAmountString) && !!walletAddress ? (
         <div className={classes.transferField}>
           <TokenSelector disabled={shouldLockFields} />
         </div>
@@ -250,7 +251,7 @@ function Source() {
             sourceChain={sourceChain}
             sourceAsset={parsedTokenAccount?.mintKey}
           />
-          {(hasParsedTokenAccount && !!walletAddress) ? (
+          {hasParsedTokenAccount && !!walletAddress ? (
             <NumberTextField
               variant="outlined"
               label="Amount"

--- a/src/components/Transfer/Source.tsx
+++ b/src/components/Transfer/Source.tsx
@@ -110,7 +110,7 @@ function Source() {
   const error = useSelector(selectTransferSourceError);
   const isSourceComplete = useSelector(selectTransferIsSourceComplete);
   const shouldLockFields = useSelector(selectTransferShouldLockFields);
-  const { isReady, statusMessage } = useIsWalletReady(sourceChain);
+  const { isReady, statusMessage, walletAddress } = useIsWalletReady(sourceChain);
   const isTransferLimited = useIsTransferLimited();
   const handleMigrationClick = useCallback(() => {
     if (sourceChain === CHAIN_ID_ETH) {
@@ -226,7 +226,7 @@ function Source() {
         </div>
       </div>
       <KeyAndBalance chainId={sourceChain} />
-      {isReady || uiAmountString ? (
+      {((isReady || uiAmountString) && !!walletAddress) ? (
         <div className={classes.transferField}>
           <TokenSelector disabled={shouldLockFields} />
         </div>
@@ -250,7 +250,7 @@ function Source() {
             sourceChain={sourceChain}
             sourceAsset={parsedTokenAccount?.mintKey}
           />
-          {hasParsedTokenAccount ? (
+          {(hasParsedTokenAccount && !!walletAddress) ? (
             <NumberTextField
               variant="outlined"
               label="Amount"


### PR DESCRIPTION
The problem was that when the wallet was disconnected, neither the token selected nor the amount input was hidden.