### PR TITLE
enforce minimum amount for Evm token transfers

### DIFF
--- a/src/components/Transfer/Source.tsx
+++ b/src/components/Transfer/Source.tsx
@@ -52,6 +52,7 @@ import { RootState } from "../../store";
 import useTransferControl from "../../hooks/useTransferControl";
 import transferRules from "../../config/transferRules";
 import useRoundTripTransfer from "../../hooks/useRoundTripTransfer";
+import useMinimumAmountGuard from "../../hooks/useMinimumAmountGuard";
 
 const useStyles = makeStyles((theme) => ({
   chainSelectWrapper: {
@@ -169,7 +170,7 @@ function Source() {
     isPandle
   );
   /* End pandle token check */
-
+  const isBelowMinimum = useMinimumAmountGuard();
   return (
     <>
       <StepDescription>
@@ -260,6 +261,8 @@ function Source() {
               value={amount}
               onChange={handleAmountChange}
               disabled={isTransferDisabled || shouldLockFields}
+              error={isBelowMinimum}
+              helperText={isBelowMinimum ? "Amount is below minimum" : ""}
               onMaxClick={
                 uiAmountString && !parsedTokenAccount.isNativeAsset
                   ? handleMaxClick

--- a/src/hooks/useMinimumAmountGuard.ts
+++ b/src/hooks/useMinimumAmountGuard.ts
@@ -1,0 +1,43 @@
+import type { RootState } from "../store";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { ChainId, isEVMChain } from "@certusone/wormhole-sdk";
+
+function checkIfIsBelowMinimum(amount: string, decimals: number) {
+  try {
+    const divider = Math.pow(10, decimals);
+    const floatAmount = parseFloat(amount);
+    const intAmount = floatAmount * divider;
+    return Math.trunc(intAmount) <= 0;
+  } catch (err: any) {
+    console.error(err);
+    return true;
+  }
+}
+
+function getAdjustedDecimals(
+  chainId: ChainId,
+  isNativeAsset: boolean,
+  decimals: number
+) {
+  return isEVMChain(chainId) && !isNativeAsset && decimals > 8
+    ? decimals - 8
+    : decimals;
+}
+
+export default function useMinimumAmountGuard() {
+  const {
+    amount,
+    sourceChain,
+    sourceParsedTokenAccount: { decimals = 0, isNativeAsset = false } = {},
+  } = useSelector((state: RootState) => state.transfer);
+  const isBelowMinimum = useMemo(
+    () =>
+      checkIfIsBelowMinimum(
+        amount,
+        getAdjustedDecimals(sourceChain, isNativeAsset, decimals)
+      ),
+    [amount, sourceChain, isNativeAsset, decimals]
+  );
+  return isBelowMinimum;
+}


### PR DESCRIPTION
For token transfers from Evm the maximum decimal supported at this moment is 8 decimals, which lends to a minimum amount of 0.00000001 to be possible to transfer, below that the Token Bridge contract rounds to zero. To avoid a lack of funds now the UI prevents users to input amounts below that amount.

see: https://github.com/wormhole-foundation/wormhole/blob/96682bdbeb7c87bfa110eade0554b3d8cbf788d2/ethereum/contracts/bridge/Bridge.sol#L259