### PR TITLE
175 Bug fix 'Cannonical token' message is not displayed on “Are you sure?” pop-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "lint-staged": "^13.2.3",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
-        "prettier": "^3.0.1",
+        "prettier": "^3.0.2",
         "process": "^0.11.10",
         "punycode": "^2.1.1",
         "querystring-es3": "^0.2.1",
@@ -35761,9 +35761,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -70106,9 +70106,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.62",
+  "version": "0.1.64",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xlabs/portal-bridge-ui",
-      "version": "0.1.62",
+      "version": "0.1.64",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.22",
         "@injectivelabs/sdk-ts": "^1.10.72",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lint-staged": "^13.2.3",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
-    "prettier": "^3.0.1",
+    "prettier": "^3.0.2",
     "process": "^0.11.10",
     "punycode": "^2.1.1",
     "querystring-es3": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xlabs/portal-bridge-ui",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "private": true,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.22",

--- a/src/components/Migration/EvmQuickMigrate.tsx
+++ b/src/components/Migration/EvmQuickMigrate.tsx
@@ -147,9 +147,8 @@ function EvmMigrationLineItem({
         poolInfo.data.migrator.address,
         migrationAmountAbs
       );
-      const transaction = await poolInfo.data.migrator.migrate(
-        migrationAmountAbs
-      );
+      const transaction =
+        await poolInfo.data.migrator.migrate(migrationAmountAbs);
       await transaction.wait();
       setTransaction(transaction.hash);
       enqueueSnackbar(null, {

--- a/src/components/SolanaCreateAssociatedAddress.tsx
+++ b/src/components/SolanaCreateAssociatedAddress.tsx
@@ -58,9 +58,8 @@ export function useAssociatedAccountExistsState(
       );
       const match = associatedAddress.toString() === readableTargetAddress;
       if (match) {
-        const associatedAddressInfo = await connection.getAccountInfo(
-          associatedAddress
-        );
+        const associatedAddressInfo =
+          await connection.getAccountInfo(associatedAddress);
         if (!associatedAddressInfo) {
           if (!cancelled) {
             setAssociatedAccountExists(false);
@@ -112,9 +111,8 @@ export default function SolanaCreateAssociatedAddress({
       );
       const match = associatedAddress.toString() === readableTargetAddress;
       if (match) {
-        const associatedAddressInfo = await connection.getAccountInfo(
-          associatedAddress
-        );
+        const associatedAddressInfo =
+          await connection.getAccountInfo(associatedAddress);
         if (!associatedAddressInfo) {
           setIsCreating(true);
           const transaction = new Transaction().add(

--- a/src/components/Transfer/TokenWarning.tsx
+++ b/src/components/Transfer/TokenWarning.tsx
@@ -188,10 +188,7 @@ export default function TokenWarning({
   const showMultiChainWarning =
     isMultiChain && isWormholeWrapped && targetChain !== CHAIN_ID_APTOS;
   const showCanonicalWarning =
-    !isMultiChain &&
-    isWormholeWrapped &&
-    targetChain !== CHAIN_ID_APTOS &&
-    showCanonicalTbtcMessage;
+    !isMultiChain && targetChain !== CHAIN_ID_APTOS && showCanonicalTbtcMessage;
   const showWrappedWarning =
     !isMultiChain &&
     isWormholeWrapped &&

--- a/src/hooks/useHandleRedeem.tsx
+++ b/src/hooks/useHandleRedeem.tsx
@@ -185,9 +185,8 @@ async function evm(
         signer
       );
 
-      const estimateGas = await L2WormholeGateway.estimateGas.receiveTbtc(
-        signedVAA
-      );
+      const estimateGas =
+        await L2WormholeGateway.estimateGas.receiveTbtc(signedVAA);
 
       // We increase the gas limit estimation here by a factor of 10% to account for some faulty public JSON-RPC endpoints.
       const gasLimit = estimateGas.mul(1100).div(1000);


### PR DESCRIPTION
The canonical message must be shown when:

- Ethereum is the target and the asset is tBTC, the canonical message should be displayed.
- Any combination of source - target with eth, polygon, arbitrum, optimism, base, and solana, with tBTC.

I deleted the isWormholeWrapped condition because It's not necessary.

Result:

![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/8b604a47-2b55-467a-8b38-bc1eac9b8070)
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/163b2703-0c58-4f4f-850f-ec4aa0f44eeb)
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/21f3daf3-61ac-48f1-ba11-a298fd14a4bb)
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/894f6732-30dc-4137-b320-39ced11fc0dc)
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/abffec4b-77cc-417e-ad8f-aeb99dde1618)
