### PR TITLE
add fix to allow sending canonical tBTC to non canonical supported network

### DIFF
--- a/src/assets/providers/tbtc/solana/WormholeGateway.v2.ts
+++ b/src/assets/providers/tbtc/solana/WormholeGateway.v2.ts
@@ -14,7 +14,10 @@ import {
   THRESHOLD_TBTC_SOLANA_PROGRAM,
 } from "../../../../utils/consts";
 import {
-  CHAIN_ID_ETH,
+  CHAIN_ID_ARBITRUM,
+  CHAIN_ID_BASE,
+  CHAIN_ID_OPTIMISM,
+  CHAIN_ID_POLYGON,
   CHAIN_ID_SOLANA,
   ChainId,
   SignedVaa,
@@ -174,6 +177,12 @@ function sendTbtcWrapped(
     .accounts(accounts)
     .transaction();
   return tx;
+}
+
+const CANNONICAL_CHAINS: number[] = [CHAIN_ID_POLYGON, CHAIN_ID_OPTIMISM, CHAIN_ID_ARBITRUM, CHAIN_ID_BASE, CHAIN_ID_SOLANA];
+
+const isCanonical = (chainId: number) => {
+  return CANNONICAL_CHAINS.includes(chainId);
 }
 
 /**
@@ -347,7 +356,7 @@ export function newThresholdWormholeGateway(
       new PublicKey(senderToken),
       new PublicKey(wallet.getAddress()!)
     );
-    if (recipientChain === CHAIN_ID_ETH) {
+    if (!isCanonical(recipientChain)) {
       const wrappedAccounts = {
         custodian,
         wrappedTbtcToken,

--- a/src/assets/providers/tbtc/solana/WormholeGateway.v2.ts
+++ b/src/assets/providers/tbtc/solana/WormholeGateway.v2.ts
@@ -179,11 +179,17 @@ function sendTbtcWrapped(
   return tx;
 }
 
-const CANNONICAL_CHAINS: number[] = [CHAIN_ID_POLYGON, CHAIN_ID_OPTIMISM, CHAIN_ID_ARBITRUM, CHAIN_ID_BASE, CHAIN_ID_SOLANA];
+const CANNONICAL_CHAINS: number[] = [
+  CHAIN_ID_POLYGON,
+  CHAIN_ID_OPTIMISM,
+  CHAIN_ID_ARBITRUM,
+  CHAIN_ID_BASE,
+  CHAIN_ID_SOLANA,
+];
 
 const isCanonical = (chainId: number) => {
   return CANNONICAL_CHAINS.includes(chainId);
-}
+};
 
 /**
  * Send tBtc beween gateways allow burn and mint of tBtc


### PR DESCRIPTION
previous behavior: Sending tBTC from Solana to Avalanche for instance was giving an contract simulation error
current behavior: Sending tBTC from Solana to Avalance (or any non canonical chain) process successfully 