### PR TITLE
Add null-guards for token balances

### DIFF
--- a/src/hooks/useGetSourceParsedTokenAccounts.ts
+++ b/src/hooks/useGetSourceParsedTokenAccounts.ts
@@ -640,18 +640,17 @@ const createNFTParsedTokenAccountFromCovalent = (
   covalent: CovalentData,
   nft_data: CovalentNFTData
 ): NFTParsedTokenAccount => {
+  let amount =
+    nft_data.token_balance == null
+      ? "0"
+      : formatUnits(nft_data.token_balance, covalent.contract_decimals);
   return {
     publicKey: walletAddress,
     mintKey: covalent.contract_address,
-    amount: nft_data.token_balance,
+    amount: nft_data.token_balance == null ? "" : nft_data.token_balance,
     decimals: covalent.contract_decimals,
-    uiAmount: Number(
-      formatUnits(nft_data.token_balance, covalent.contract_decimals)
-    ),
-    uiAmountString: formatUnits(
-      nft_data.token_balance,
-      covalent.contract_decimals
-    ),
+    uiAmount: Number(amount),
+    uiAmountString: amount,
     symbol: covalent.contract_ticker_symbol,
     name: covalent.contract_name,
     logo: covalent.logo_url,
@@ -689,7 +688,7 @@ export type CovalentNFTExternalData = {
 
 export type CovalentNFTData = {
   token_id: string;
-  token_balance: string;
+  token_balance: string | null;
   external_data: CovalentNFTExternalData;
   token_url: string;
 };

--- a/src/hooks/useGetSourceParsedTokenAccounts.ts
+++ b/src/hooks/useGetSourceParsedTokenAccounts.ts
@@ -640,7 +640,7 @@ const createNFTParsedTokenAccountFromCovalent = (
   covalent: CovalentData,
   nft_data: CovalentNFTData
 ): NFTParsedTokenAccount => {
-  let amount =
+  const amount =
     nft_data.token_balance == null
       ? "0"
       : formatUnits(nft_data.token_balance, covalent.contract_decimals);

--- a/src/hooks/useGetSourceParsedTokenAccounts.ts
+++ b/src/hooks/useGetSourceParsedTokenAccounts.ts
@@ -640,14 +640,13 @@ const createNFTParsedTokenAccountFromCovalent = (
   covalent: CovalentData,
   nft_data: CovalentNFTData
 ): NFTParsedTokenAccount => {
-  const amount =
-    nft_data.token_balance == null
-      ? "0"
-      : formatUnits(nft_data.token_balance, covalent.contract_decimals);
+  const amount = nft_data.token_balance
+    ? formatUnits(nft_data.token_balance, covalent.contract_decimals)
+    : "0";
   return {
     publicKey: walletAddress,
     mintKey: covalent.contract_address,
-    amount: nft_data.token_balance == null ? "" : nft_data.token_balance,
+    amount: nft_data.token_balance ? nft_data.token_balance : "",
     decimals: covalent.contract_decimals,
     uiAmount: Number(amount),
     uiAmountString: amount,


### PR DESCRIPTION
Fixes #515 

Update the type definition for data coming back from Covalent API endpoints to allow for nulls, and then guard against null values when enumerating NFT data