### PR TITLE
#689 - remove rule that prevents to transfer wrapped native assets back to terra classic

### DIFF
--- a/src/config/transferRules.ts
+++ b/src/config/transferRules.ts
@@ -44,7 +44,7 @@ const transferRules: Rule[] = [
       source === CHAIN_ID_AURORA || target === CHAIN_ID_AURORA,
     text: AuroraMessage,
     disableTransfer: true,
-  }/*,
+  } /*,
   {
     id: "terra-classic-native",
     predicate: ({ target, token }: PredicateArgs) =>

--- a/src/config/transferRules.ts
+++ b/src/config/transferRules.ts
@@ -1,7 +1,7 @@
 import {
   CHAIN_ID_BSC,
   CHAIN_ID_ETH,
-//  CHAIN_ID_TERRA,
+  //  CHAIN_ID_TERRA,
   CHAIN_ID_AURORA,
 } from "@certusone/wormhole-sdk";
 // import { terra } from "@certusone/wormhole-sdk";

--- a/src/config/transferRules.ts
+++ b/src/config/transferRules.ts
@@ -1,10 +1,10 @@
 import {
   CHAIN_ID_BSC,
   CHAIN_ID_ETH,
-  CHAIN_ID_TERRA,
+//  CHAIN_ID_TERRA,
   CHAIN_ID_AURORA,
 } from "@certusone/wormhole-sdk";
-import { terra } from "@certusone/wormhole-sdk";
+// import { terra } from "@certusone/wormhole-sdk";
 import { Rule, PredicateArgs } from "../hooks/useWarningRulesEngine";
 
 const ETHEREUM_PANDLE_ADDRESS = "0X808507121B80C02388FAD14726482E061B8DA827";

--- a/src/config/transferRules.ts
+++ b/src/config/transferRules.ts
@@ -27,8 +27,8 @@ const PANDLE_MESSAGE =
   "Pandle transfers are limited to Ethereum to BSC and BSC to Ethereum.";
 const AuroraMessage =
   "As a precautionary measure, Wormhole Network and Portal have paused Aurora support temporarily.";
-const TERRA_CLASSIC_MESSAGE =
-  "Transfers of native tokens to Terra Classic have been temporarily paused.";
+/*const TERRA_CLASSIC_MESSAGE =
+  "Transfers of native tokens to Terra Classic have been temporarily paused.";*/
 
 const transferRules: Rule[] = [
   {
@@ -44,14 +44,14 @@ const transferRules: Rule[] = [
       source === CHAIN_ID_AURORA || target === CHAIN_ID_AURORA,
     text: AuroraMessage,
     disableTransfer: true,
-  },
+  }/*,
   {
     id: "terra-classic-native",
     predicate: ({ target, token }: PredicateArgs) =>
       target === CHAIN_ID_TERRA && terra.isNativeDenom(token),
     text: TERRA_CLASSIC_MESSAGE,
     disableTransfer: true,
-  },
+  }*/,
 ];
 
 export default transferRules;


### PR DESCRIPTION
- removed rule that prevents bridge back wrapped native assets to terra classic