### PR TITLE
Include token and requiredNetwork in query params

### DIFF
--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -11,7 +11,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "prettier": "prettier --write ./src",
+    "prettier": "prettier --check ./src",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -33,12 +33,12 @@ export default function Root() {
     ...defaultConfig?.tokensConfig,
   };
   if (allTokens) {
-    const tokenParam = Object.entries(allTokens).find(
+    const tokenParam = Object.values(allTokens).find(
       (config) =>
-        config[1]?.tokenId?.address === asset || config[1]?.key === asset
+        config?.tokenId?.address === asset || config?.key === asset
     );
     if (tokenParam) {
-      tokenKey = tokenParam[1].key;
+      tokenKey = tokenParam.key;
     }
   }
   const config = useMemo(

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -13,11 +13,15 @@ import { eventHandler } from "./providers/telemetry";
 
 const defaultConfig: WormholeConnectConfig = {
   ...wormholeConnectConfig,
-  ...((window.location.origin.includes("preview") || window.location.origin.includes("testnet")) && { eventHandler: eventHandler,})
+  ...((window.location.origin.includes("preview") ||
+    window.location.origin.includes("testnet")) && {
+    eventHandler: eventHandler,
+  }),
 };
 
 export default function Root() {
-  const { txHash, sourceChain, targetChain } = useQueryParams();
+  const { txHash, sourceChain, targetChain, token, requiredNetwork } = useQueryParams();
+
   const config = useMemo(
     () => ({
       ...defaultConfig,
@@ -28,15 +32,21 @@ export default function Root() {
       bridgeDefaults: {
         ...(sourceChain && { fromNetwork: sourceChain as ChainName }),
         ...(targetChain && { toNetwork: targetChain as ChainName }),
+        ...(token && { token: token as string }),
+        ...(requiredNetwork && { requiredNetwork: requiredNetwork as ChainName }),
       },
     }),
-    [txHash, sourceChain, targetChain]
+    [txHash, sourceChain, targetChain, token, requiredNetwork]
   );
   const messages = Object.values(messageConfig);
   return (
     <>
       {versions.map(({ appName, version }, idx) => (
-        <meta name={appName} content={version} key={`${appName}-${version}-${idx}`} />
+        <meta
+          name={appName}
+          content={version}
+          key={`${appName}-${version}-${idx}`}
+        />
       ))}
       <div>
         <NewsBar messages={messages} />

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -22,7 +22,15 @@ const defaultConfig: WormholeConnectConfig = {
 export default function Root() {
   const { txHash, sourceChain, targetChain, token, requiredNetwork } =
     useQueryParams();
-
+  let tokenKey = token;
+  if (defaultConfig?.tokensConfig) {
+    const tokenParam = Object.entries(defaultConfig?.tokensConfig).find(
+      (config) => config[1].tokenId.address === token
+    );
+    if (tokenParam) {
+      tokenKey = tokenParam[1].key;
+    }
+  }
   const config = useMemo(
     () => ({
       ...defaultConfig,
@@ -33,14 +41,15 @@ export default function Root() {
       bridgeDefaults: {
         ...(sourceChain && { fromNetwork: sourceChain as ChainName }),
         ...(targetChain && { toNetwork: targetChain as ChainName }),
-        ...(token && { token: token as string }),
+        ...(tokenKey && { token: tokenKey as string }),
         ...(requiredNetwork && {
           requiredNetwork: requiredNetwork as ChainName,
         }),
       },
     }),
-    [txHash, sourceChain, targetChain, token, requiredNetwork]
+    [txHash, sourceChain, targetChain, tokenKey, requiredNetwork]
   );
+
   const messages = Object.values(messageConfig);
   return (
     <>

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -8,10 +8,8 @@ import NavBar from "./components/atoms/NavBar";
 import NewsBar from "./components/atoms/NewsBar";
 import messageConfig from "./configs/messages";
 import { useQueryParams } from "./hooks/useQueryParams";
-import WormholeConnect, {
-  MAINNET,
-  TESTNET,
-} from "@wormhole-foundation/wormhole-connect";
+import { useFormatAssetParam } from "./hooks/useFormatAssetParam";
+import WormholeConnect from "@wormhole-foundation/wormhole-connect";
 import { eventHandler } from "./providers/telemetry";
 
 const defaultConfig: WormholeConnectConfig = {
@@ -21,25 +19,11 @@ const defaultConfig: WormholeConnectConfig = {
     eventHandler: eventHandler,
   }),
 };
-const tokensList =
-  defaultConfig.env === "mainnet" ? MAINNET.tokens : TESTNET.tokens;
+
 export default function Root() {
   const { txHash, sourceChain, targetChain, asset, requiredNetwork } =
     useQueryParams();
-
-  let tokenKey: string | undefined = undefined;
-  const allTokens = {
-    ...tokensList,
-    ...defaultConfig?.tokensConfig,
-  };
-  if (allTokens) {
-    const tokenParam = Object.values(allTokens).find(
-      (config) => config?.tokenId?.address === asset || config?.key === asset
-    );
-    if (tokenParam) {
-      tokenKey = tokenParam.key;
-    }
-  }
+  const tokenKey = useFormatAssetParam(asset);
   const config = useMemo(
     () => ({
       ...defaultConfig,

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -8,7 +8,10 @@ import NavBar from "./components/atoms/NavBar";
 import NewsBar from "./components/atoms/NewsBar";
 import messageConfig from "./configs/messages";
 import { useQueryParams } from "./hooks/useQueryParams";
-import WormholeConnect, { MAINNET, TESTNET } from "@wormhole-foundation/wormhole-connect";
+import WormholeConnect, {
+  MAINNET,
+  TESTNET,
+} from "@wormhole-foundation/wormhole-connect";
 import { eventHandler } from "./providers/telemetry";
 
 const defaultConfig: WormholeConnectConfig = {
@@ -18,7 +21,8 @@ const defaultConfig: WormholeConnectConfig = {
     eventHandler: eventHandler,
   }),
 };
-const tokensList = defaultConfig.env === 'mainnet' ? MAINNET.tokens : TESTNET.tokens;
+const tokensList =
+  defaultConfig.env === "mainnet" ? MAINNET.tokens : TESTNET.tokens;
 export default function Root() {
   const { txHash, sourceChain, targetChain, asset, requiredNetwork } =
     useQueryParams();
@@ -30,7 +34,8 @@ export default function Root() {
   };
   if (allTokens) {
     const tokenParam = Object.entries(allTokens).find(
-      (config) => config[1]?.tokenId?.address === asset || config[1]?.key === asset
+      (config) =>
+        config[1]?.tokenId?.address === asset || config[1]?.key === asset
     );
     if (tokenParam) {
       tokenKey = tokenParam[1].key;

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -34,8 +34,7 @@ export default function Root() {
   };
   if (allTokens) {
     const tokenParam = Object.values(allTokens).find(
-      (config) =>
-        config?.tokenId?.address === asset || config?.key === asset
+      (config) => config?.tokenId?.address === asset || config?.key === asset
     );
     if (tokenParam) {
       tokenKey = tokenParam.key;

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -8,7 +8,7 @@ import NavBar from "./components/atoms/NavBar";
 import NewsBar from "./components/atoms/NewsBar";
 import messageConfig from "./configs/messages";
 import { useQueryParams } from "./hooks/useQueryParams";
-import WormholeConnect from "@wormhole-foundation/wormhole-connect";
+import WormholeConnect, { MAINNET, TESTNET } from "@wormhole-foundation/wormhole-connect";
 import { eventHandler } from "./providers/telemetry";
 
 const defaultConfig: WormholeConnectConfig = {
@@ -18,14 +18,19 @@ const defaultConfig: WormholeConnectConfig = {
     eventHandler: eventHandler,
   }),
 };
-
+const tokensList = defaultConfig.env === 'mainnet' ? MAINNET.tokens : TESTNET.tokens;
 export default function Root() {
-  const { txHash, sourceChain, targetChain, token, requiredNetwork } =
+  const { txHash, sourceChain, targetChain, asset, requiredNetwork } =
     useQueryParams();
-  let tokenKey = token;
-  if (defaultConfig?.tokensConfig) {
-    const tokenParam = Object.entries(defaultConfig?.tokensConfig).find(
-      (config) => config[1].tokenId.address === token
+
+  let tokenKey: string | undefined = undefined;
+  const allTokens = {
+    ...tokensList,
+    ...defaultConfig?.tokensConfig,
+  };
+  if (allTokens) {
+    const tokenParam = Object.entries(allTokens).find(
+      (config) => config[1]?.tokenId?.address === asset || config[1]?.key === asset
     );
     if (tokenParam) {
       tokenKey = tokenParam[1].key;

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -20,7 +20,8 @@ const defaultConfig: WormholeConnectConfig = {
 };
 
 export default function Root() {
-  const { txHash, sourceChain, targetChain, token, requiredNetwork } = useQueryParams();
+  const { txHash, sourceChain, targetChain, token, requiredNetwork } =
+    useQueryParams();
 
   const config = useMemo(
     () => ({
@@ -33,7 +34,9 @@ export default function Root() {
         ...(sourceChain && { fromNetwork: sourceChain as ChainName }),
         ...(targetChain && { toNetwork: targetChain as ChainName }),
         ...(token && { token: token as string }),
-        ...(requiredNetwork && { requiredNetwork: requiredNetwork as ChainName }),
+        ...(requiredNetwork && {
+          requiredNetwork: requiredNetwork as ChainName,
+        }),
       },
     }),
     [txHash, sourceChain, targetChain, token, requiredNetwork]

--- a/apps/connect/src/configs/messages.tsx
+++ b/apps/connect/src/configs/messages.tsx
@@ -60,7 +60,7 @@ const messages: Record<string, Message> = {
       </>
     ),
     start: new Date("2024-01-17T10:00:00-05:00"), // any date in the past would be fine
-    ends: new Date("2024-06-20T10:00:00-05:00"), 
+    ends: new Date("2024-06-20T10:00:00-05:00"),
   },
   cctp: {
     background: "linear-gradient(20deg, #f44b1b 0%, #eeb430 100%);",

--- a/apps/connect/src/hooks/useFormatAssetParam.ts
+++ b/apps/connect/src/hooks/useFormatAssetParam.ts
@@ -20,9 +20,6 @@ function getFormatedAsset(asset: string | null): string | null {
 }
 
 export function useFormatAssetParam(asset: string | null) {
-  const formatedAsset = useMemo(
-    () => getFormatedAsset(asset),
-    [asset]
-  );
+  const formatedAsset = useMemo(() => getFormatedAsset(asset), [asset]);
   return formatedAsset;
 }

--- a/apps/connect/src/hooks/useFormatAssetParam.ts
+++ b/apps/connect/src/hooks/useFormatAssetParam.ts
@@ -1,0 +1,28 @@
+import { MAINNET, TESTNET } from "@wormhole-foundation/wormhole-connect";
+import { useMemo } from "react";
+
+const tokensList =
+  wormholeConnectConfig.env === "mainnet" ? MAINNET.tokens : TESTNET.tokens;
+function getFormatedAsset(asset: string | null): string | null {
+  const allTokens = {
+    ...tokensList,
+    ...wormholeConnectConfig?.tokensConfig,
+  };
+  if (allTokens && asset) {
+    const tokenParam = Object.values(allTokens).find(
+      (config) => config?.tokenId?.address === asset || config?.key === asset
+    );
+    if (tokenParam) {
+      return tokenParam.key;
+    }
+  }
+  return null;
+}
+
+export function useFormatAssetParam(asset: string | null) {
+  const formatedAsset = useMemo(
+    () => getFormatedAsset(asset),
+    [asset]
+  );
+  return formatedAsset;
+}

--- a/apps/connect/src/hooks/useQueryParams.ts
+++ b/apps/connect/src/hooks/useQueryParams.ts
@@ -17,6 +17,11 @@ function getChainValue(query: URLSearchParams, key: string): ChainName | null {
   return null;
 }
 
+function getTokenValue(query: URLSearchParams, key: string): string | null {
+  const token = query.get(key);
+  return token && token.length > 0 ? token : null;
+}
+
 function getTxHash(query: URLSearchParams): string | null {
   const txHash = query.get("txHash");
   const transactionId = query.get("transactionId");
@@ -38,10 +43,17 @@ export function useQueryParams() {
     () => getChainValue(query, "targetChain"),
     [query]
   );
+  const requiredNetwork = useMemo(
+    () => getChainValue(query, "requiredNetwork"),
+    [query]
+  );
   const txHash = useMemo(() => getTxHash(query), [query]);
+  const token = useMemo(() => getTokenValue(query, "token"), [query]);
   return {
     txHash,
     sourceChain,
     targetChain,
+    token,
+    requiredNetwork,
   };
 }

--- a/apps/connect/src/hooks/useQueryParams.ts
+++ b/apps/connect/src/hooks/useQueryParams.ts
@@ -48,12 +48,12 @@ export function useQueryParams() {
     [query]
   );
   const txHash = useMemo(() => getTxHash(query), [query]);
-  const token = useMemo(() => getTokenValue(query, "token"), [query]);
+  const asset = useMemo(() => getTokenValue(query, "asset"), [query]);
   return {
     txHash,
     sourceChain,
     targetChain,
-    token,
+    asset,
     requiredNetwork,
   };
 }


### PR DESCRIPTION
Examples:

`?sourceChain=bsc&targetChain=arbitrum&asset=WETHbsc`
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/2e162044-f3e3-405f-82a6-d8bbb9b56a27)


`?sourceChain=bsc&targetChain=arbitrum&asset=0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d`
![image](https://github.com/XLabs/portal-bridge-ui/assets/35125931/02b5526a-649e-4a32-a98e-5e296242d918)

