### PR TITLE
[bug] [Testnet] Wormholescan link redirects user to Mainnet stats

### DIFF
--- a/apps/connect/src/components/atoms/NavBar.tsx
+++ b/apps/connect/src/components/atoms/NavBar.tsx
@@ -84,7 +84,11 @@ const Spacer = styled("div")(() => ({
 // const chipNew = <Chip label="NEW" size="small" />; // TODO: Add back when needed
 const womrholescanButton = (
   <Box>
-    <Link href="https://wormholescan.io" target="_blank" color="inherit">
+    <Link
+      href={`https://wormholescan.io${wormholeConnectConfig.env === "testnet" ? "/#/?network=TESTNET" : ""}`}
+      target="_blank"
+      color="inherit"
+    >
       Wormholescan
     </Link>
   </Box>


### PR DESCRIPTION
[[bug] [Testnet] Wormholescan link redirects user to Mainnet stats](https://github.com/XLabs/portal-bridge-ui/issues/551)


### testnet

https://github.com/XLabs/portal-bridge-ui/assets/19752365/6d2eb0df-7af3-4def-8fcf-c3954d00eb97

### mainnet

https://github.com/XLabs/portal-bridge-ui/assets/19752365/72c28d0b-78b8-49c3-9b6c-56326cddfa0e

