### PR TITLE
[bugs] Portal bridge transfer route has empty content

### DIFF
--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -73,8 +73,8 @@ export default function Root() {
     </>
   );
   const routes = useRoutes([
-    { path: `/`, element: Connect },
     { path: PrivacyPolicyPath, element: <PrivacyPolicy /> },
+    { path: '*', element: Connect },
   ]);
   return (
     <>

--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -74,7 +74,7 @@ export default function Root() {
   );
   const routes = useRoutes([
     { path: PrivacyPolicyPath, element: <PrivacyPolicy /> },
-    { path: '*', element: Connect },
+    { path: "*", element: Connect },
   ]);
   return (
     <>

--- a/apps/connect/src/hooks/useQueryParams.ts
+++ b/apps/connect/src/hooks/useQueryParams.ts
@@ -34,7 +34,16 @@ function getTxHash(query: URLSearchParams): string | null {
 }
 
 export function useQueryParams() {
-  const query = useMemo(() => new URLSearchParams(window.location.search), []);
+  const query = useMemo(
+    () =>
+      new URLSearchParams(
+        window.location.href.substring(
+          window.location.href.indexOf("?"),
+          window.location.href.length
+        )
+      ),
+    []
+  );
   const sourceChain = useMemo(
     () => getChainValue(query, "sourceChain"),
     [query]


### PR DESCRIPTION
[[bugs] Portal bridge transfer route has empty content](https://github.com/XLabs/portal-bridge-ui-issues/issues/109)

* Fixed router to use a wildcard for connect after trying to match the privacy policy route
* Change on the `useQueryParams` to allow for qs after url hashes (/#/transfer?qs...)

[https://preview.portalbridge.com/d656da0029/#/transfer?sourceChain=bsc&targetChain=arbitrum](https://preview.portalbridge.com/d656da0029/#/transfer?sourceChain=bsc&targetChain=arbitrum)

<img width="1206" alt="image" src="https://github.com/XLabs/portal-bridge-ui/assets/19752365/cff3dbb0-551a-46ae-99ae-49143f25623f">
<img width="1199" alt="image" src="https://github.com/XLabs/portal-bridge-ui/assets/19752365/99992f45-08c9-4c99-8ea2-4fc781e80f6d">
<img width="1228" alt="image" src="https://github.com/XLabs/portal-bridge-ui/assets/19752365/dcc00e26-076c-4f01-a3e0-e28d85989ab1">
<img width="1230" alt="image" src="https://github.com/XLabs/portal-bridge-ui/assets/19752365/26c0c3d5-1ef6-4710-9fb2-d40a58693614">
