### PR TITLE
Revert "Fix wstETH symbol (#928)"

### DIFF
--- a/apps/connect/src/env/token-bridge.mainnet.ts
+++ b/apps/connect/src/env/token-bridge.mainnet.ts
@@ -308,7 +308,7 @@ export const ENV: Env = {
         },
         "wstETH ": {
           key: "wstETH ",
-          symbol: "wstETH",
+          symbol: "wstETH ",
           nativeChain: "bsc",
           tokenId: {
             chain: "bsc",


### PR DESCRIPTION
we need to revert this fix, since the symbol needs to match with the tokenKey

This reverts commit 4718f17972952325d62991f3c60978a5c1e9deff.