### PR TITLE
Updated QS to be able to specify route

### DIFF
--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -1,7 +1,4 @@
-import type {
-  ChainName,
-  WormholeConnectConfig,
-} from "@wormhole-foundation/wormhole-connect";
+import type { WormholeConnectConfig } from "@wormhole-foundation/wormhole-connect";
 import { ComponentProps, useEffect, useMemo } from "react";
 import customTheme from "./theme/connect";
 import NavBar from "./components/atoms/NavBar";
@@ -39,26 +36,25 @@ const defaultConfig: WormholeConnectConfig = {
 };
 
 export default function Root() {
-  const { txHash, sourceChain, targetChain, asset, requiredNetwork } =
+  const { txHash, sourceChain, targetChain, asset, requiredNetwork, route } =
     useQueryParams();
-  const tokenKey = useFormatAssetParam(asset);
+  const token = useFormatAssetParam(asset);
   const config: ComponentProps<typeof WormholeConnect>["config"] = useMemo(
     () => ({
       ...defaultConfig,
       searchTx: {
         ...(txHash && { txHash }),
-        ...(sourceChain && { chainName: sourceChain as ChainName }),
+        ...(sourceChain && { chainName: sourceChain }),
       },
       bridgeDefaults: {
-        ...(sourceChain && { fromNetwork: sourceChain as ChainName }),
-        ...(targetChain && { toNetwork: targetChain as ChainName }),
-        ...(tokenKey && { token: tokenKey as string }),
-        ...(requiredNetwork && {
-          requiredNetwork: requiredNetwork as ChainName,
-        }),
+        ...(sourceChain && { fromNetwork: sourceChain }),
+        ...(targetChain && { toNetwork: targetChain }),
+        ...(token && { token }),
+        ...(requiredNetwork && { requiredNetwork }),
       },
+      ...(route && { routes: [route] }),
     }),
-    [txHash, sourceChain, targetChain, tokenKey, requiredNetwork]
+    [txHash, sourceChain, targetChain, token, requiredNetwork, route]
   );
 
   const messages = Object.values(messageConfig);

--- a/apps/connect/src/hooks/useQueryParams.test.ts
+++ b/apps/connect/src/hooks/useQueryParams.test.ts
@@ -22,24 +22,13 @@ describe("useQueryParams", () => {
       sourceChain: null,
       targetChain: null,
       txHash: null,
-    });
-  });
-
-  it("should get QS when there is no query", () => {
-    rewriteHref("https://portalbridge.com/");
-    const { result } = renderHook(() => useQueryParams());
-    expect(result.current).toEqual({
-      asset: null,
-      requiredNetwork: null,
-      sourceChain: null,
-      targetChain: null,
-      txHash: null,
+      route: null,
     });
   });
 
   it("should get QS when query contains all expected attrs after a hash #", () => {
     rewriteHref(
-      "https://portalbridge.com/#/?sourceChain=bsc&targetChain=arbitrum&requiredNetwork=arbitrum&txHash=txHash&asset=asset"
+      "https://portalbridge.com/#/?sourceChain=bsc&targetChain=arbitrum&requiredNetwork=arbitrum&txHash=txHash&asset=asset&route=bridge"
     );
     const { result } = renderHook(() => useQueryParams());
     expect(result.current).toEqual({
@@ -48,12 +37,13 @@ describe("useQueryParams", () => {
       sourceChain: "bsc",
       targetChain: "arbitrum",
       txHash: "txHash",
+      route: "bridge",
     });
   });
 
   it("should get QS when query contains all expected attrs when there is no hash", () => {
     rewriteHref(
-      "https://portalbridge.com/?sourceChain=bsc&targetChain=arbitrum&requiredNetwork=arbitrum&txHash=txHash&asset=asset"
+      "https://portalbridge.com/?sourceChain=bsc&targetChain=arbitrum&requiredNetwork=arbitrum&txHash=txHash&asset=asset&route=bridge"
     );
     const { result } = renderHook(() => useQueryParams());
     expect(result.current).toEqual({
@@ -62,6 +52,7 @@ describe("useQueryParams", () => {
       sourceChain: "bsc",
       targetChain: "arbitrum",
       txHash: "txHash",
+      route: "bridge",
     });
   });
 
@@ -74,6 +65,7 @@ describe("useQueryParams", () => {
       sourceChain: null,
       targetChain: null,
       txHash: "transactionId",
+      route: null,
     });
   });
 
@@ -88,6 +80,7 @@ describe("useQueryParams", () => {
       sourceChain: "bsc",
       targetChain: "arbitrum",
       txHash: null,
+      route: null,
     });
   });
 });

--- a/apps/connect/src/hooks/useQueryParams.ts
+++ b/apps/connect/src/hooks/useQueryParams.ts
@@ -1,7 +1,10 @@
 import { ChainName, coalesceChainName, isChain } from "@certusone/wormhole-sdk";
 import { useMemo } from "react";
 
-function getChainValue(query: URLSearchParams, key: string): ChainName | null {
+const getChainValue = (
+  query: URLSearchParams,
+  key: string
+): ChainName | null => {
   const sourceChain = query.get(key);
   if (sourceChain) {
     if (isChain(sourceChain)) {
@@ -14,18 +17,22 @@ function getChainValue(query: URLSearchParams, key: string): ChainName | null {
     }
   }
   return null;
-}
+};
 
-function getTokenValue(query: URLSearchParams, key: string): string | null {
+const getTokenValue = (query: URLSearchParams, key: string): string | null => {
   const token = query.get(key);
   return token?.length ? token : null;
-}
+};
 
-function getTxHash(query: URLSearchParams): string | null {
+const getTxHash = (query: URLSearchParams): string | null => {
   return query.get("txHash") || query.get("transactionId") || null;
-}
+};
 
-export function useQueryParams() {
+const getRoute = (query: URLSearchParams): string | null => {
+  return query.get("route") || null;
+};
+
+export const useQueryParams = () => {
   const query = useMemo(
     () =>
       new URLSearchParams(
@@ -44,7 +51,8 @@ export function useQueryParams() {
       targetChain: getChainValue(query, "targetChain"),
       asset: getTokenValue(query, "asset"),
       requiredNetwork: getChainValue(query, "requiredNetwork"),
+      route: getRoute(query),
     }),
     [query]
   );
-}
+};


### PR DESCRIPTION
[Update query parameter functionality to be able to specify target asset](https://github.com/XLabs/portal-bridge-ui-issues/issues/106)

Since it's not possible to specify the target asset independently from the source asset, only the `route` qs was added which should cover the use case

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/5249bd38-c01c-4ad2-be71-0046bb497d4b">

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/14ebfd5f-bc72-4b99-a06d-fa17d1463a52">
