### PR TITLE
Update VAA Repair/Redeem to support newest protocols in advanced tool 

### DIFF
--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -2244,3 +2244,9 @@ export const getWormholescanLink = (tx: string) => {
     process.env.REACT_APP_CLUSTER === "mainnet" ? "MAINNET" : "TESTNET"
   }`;
 };
+
+export const getTxFromVaaApiRef = (vaaID: string) => {
+  return `https://api.${
+    process.env.REACT_APP_CLUSTER === "mainnet" ? "" : "testnet."
+  }wormholescan.io/api/v1/operations/${vaaID}`;
+};


### PR DESCRIPTION
[Update VAA Repair/Redeem to support newest protocols in advanced tool ](https://github.com/XLabs/portal-bridge-ui-issues/issues/86)

Changed the flow to redirect to the new recovery tools pre-populated with the correct chain and tx

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/4559de81-3920-4dab-9ccc-793d1999a338">

<img width="993" alt="image" src="https://github.com/user-attachments/assets/2724f682-a5a3-4527-afd9-10037545295b">

<img width="838" alt="image" src="https://github.com/user-attachments/assets/9a862926-9433-467b-a622-752a4543fa8d">
