### PR TITLE
[bug] Failed to load wallets after returning from Privacy Policy page

### DIFF
--- a/apps/connect/src/App.tsx
+++ b/apps/connect/src/App.tsx
@@ -1,5 +1,5 @@
 import type { WormholeConnectConfig } from "@wormhole-foundation/wormhole-connect";
-import { ComponentProps, useEffect, useMemo } from "react";
+import { ComponentProps, memo, useEffect, useMemo } from "react";
 import customTheme from "./theme/connect";
 import NavBar from "./components/atoms/NavBar";
 import NewsBar from "./components/atoms/NewsBar";
@@ -8,7 +8,7 @@ import { useQueryParams } from "./hooks/useQueryParams";
 import { useFormatAssetParam } from "./hooks/useFormatAssetParam";
 import WormholeConnect from "@wormhole-foundation/wormhole-connect";
 import { eventHandler, type WormholeConnectEvent } from "./providers/telemetry";
-import { useRoutes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import PrivacyPolicy from "./components/pages/PrivacyPolicy";
 import { PrivacyPolicyPath, isPreview, isProduction } from "./utils/constants";
 import Banner from "./components/atoms/Banner";
@@ -48,6 +48,17 @@ const defaultConfig: WormholeConnectConfig = {
   },
 };
 
+const Connect = memo(
+  ({ config }: Pick<ComponentProps<typeof WormholeConnect>, "config">) => {
+    return (
+      <>
+        <WormholeConnect config={config} theme={customTheme} />
+        <Banner />
+      </>
+    );
+  }
+);
+
 export default function Root() {
   const { txHash, sourceChain, targetChain, asset, requiredNetwork, route } =
     useQueryParams();
@@ -76,16 +87,6 @@ export default function Root() {
     localStorage.setItem("Connect Config", JSON.stringify(config, null, 2));
   }, [config]);
 
-  const Connect = (
-    <>
-      <WormholeConnect config={config} theme={customTheme} />
-      <Banner />
-    </>
-  );
-  const routes = useRoutes([
-    { path: PrivacyPolicyPath, element: <PrivacyPolicy /> },
-    { path: "*", element: Connect },
-  ]);
   return (
     <>
       {ENV.versions.map(({ appName, version }, idx) => (
@@ -99,7 +100,10 @@ export default function Root() {
         <NewsBar messages={messages} />
         <NavBar />
       </div>
-      {routes}
+      <Routes>
+        <Route path={PrivacyPolicyPath} element={<PrivacyPolicy />} />
+        <Route path="*" element={<Connect config={config} />} />
+      </Routes>
     </>
   );
 }

--- a/apps/connect/src/components/atoms/Banner.tsx
+++ b/apps/connect/src/components/atoms/Banner.tsx
@@ -13,7 +13,7 @@ const BannerContainer = styled("div")(({ theme }) => ({
   bottom: 60,
   left: 30,
   right: 30,
-  zIndex: 100,
+  zIndex: 10,
   [theme.breakpoints.down("sm")]: {
     bottom: 75,
   },

--- a/apps/connect/src/components/atoms/TableOfContent.tsx
+++ b/apps/connect/src/components/atoms/TableOfContent.tsx
@@ -45,7 +45,6 @@ export default function TableOfContent() {
     borderLeft: "3px solid white",
   };
   useEffect(() => {
-    console.log("TableOfContent", document.querySelectorAll("H2"));
     const titles = Array.from(document.querySelectorAll("H2"))
       .filter((el) => !!el.children[0].textContent)
       .map((el) => {


### PR DESCRIPTION
[[bug] Failed to load wallets after returning from Privacy Policy page]([bug] Failed to load wallets after returning from Privacy Policy page)

* Moved the banner below connect's modals
* Removed a leftover `console.log`
* Code styling on router