### PR TITLE
bugs/aptos transfer can not initiate to the wormhole sdk comment

### DIFF
--- a/src/hooks/useHandleTransfer.tsx
+++ b/src/hooks/useHandleTransfer.tsx
@@ -282,19 +282,20 @@ async function aptos(
     const baseAmountParsed = parseUnits(amount, decimals);
     const feeParsed = parseUnits(relayerFee || "0", decimals);
     const transferAmountParsed = baseAmountParsed.add(feeParsed);
-
-    const additionalPayload = maybeAdditionalPayload();
-
+    // Aptos does not support additional payload, comment out for now
+    // See https://github.com/wormhole-foundation/wormhole/blob/main/sdk/js/src/token_bridge/transfer.ts#L901
+    // const additionalPayload = maybeAdditionalPayload();
     const transferPayload = transferFromAptos(
       tokenBridgeAddress,
       tokenAddress,
       transferAmountParsed.toString(),
       recipientChain,
-      additionalPayload?.receivingContract || recipientAddress,
-      additionalPayload?.payload
-        ? undefined
-        : createNonce().readUInt32LE(0).toString(),
-      additionalPayload?.payload
+      recipientAddress,
+      //additionalPayload?.receivingContract || recipientAddress,
+      //additionalPayload?.payload
+      //  ? undefined
+      //  : createNonce().readUInt32LE(0).toString(),
+      //additionalPayload?.payload
     );
 
     const hash = await waitForSignAndSubmitTransaction(transferPayload, wallet);

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -3,6 +3,8 @@ const MM_ERR_WITH_INFO_START =
 const DEFAULT_ERROR_MESSAGE = "An unknown error occurred";
 
 const parseError = (e: any): string => {
+  // Logs more information about the error
+  console.trace(e);
   if (e?.data?.message?.startsWith(MM_ERR_WITH_INFO_START)) {
     return e.data.message.replace(MM_ERR_WITH_INFO_START, "");
   }


### PR DESCRIPTION
the additional payload was introducing a wrong relayerFee value since aptos does not support additional payload, the whole code was stripped out related to additional payload

- now a transfer can be initiated without on-chain error
- still exist an error thrown by the wallet adapter 